### PR TITLE
fix(inbound): listener error recovery and panic hardening

### DIFF
--- a/clash-bin/build.rs
+++ b/clash-bin/build.rs
@@ -2,15 +2,16 @@
 #![cfg_attr(not(version("1.88.0")), feature(let_chains))]
 
 fn main() {
-    // Watch both CLASH_* and GitHub-provided env vars so rebuilds trigger correctly
+    // Watch both CLASH_* and GitHub-provided env vars so rebuilds trigger
+    // correctly
     let vars = ["CLASH_GIT_REF", "CLASH_GIT_SHA", "GITHUB_REF", "GITHUB_SHA"];
     for var in vars {
         println!("cargo:rerun-if-env-changed={var}");
     }
 
-    // Prefer explicit CLASH_* vars; fall back to GITHUB_* which are set by GitHub
-    // Actions. Use std::env::var_os to read at runtime, not option_env! at compile
-    // time.
+    // Prefer explicit CLASH_* vars; fall back to GITHUB_* which are set by
+    // GitHub Actions. Use std::env::var_os to read at runtime, not
+    // option_env! at compile time.
     let git_ref = std::env::var_os("CLASH_GIT_REF")
         .or_else(|| std::env::var_os("GITHUB_REF"))
         .and_then(|v| v.into_string().ok());

--- a/clash-bin/src/main.rs
+++ b/clash-bin/src/main.rs
@@ -107,7 +107,8 @@ fn main() -> anyhow::Result<()> {
     let _profiler = dhat::Profiler::new_heap();
 
     // Those arguments are for compatibility with `mihomo`
-    // Technically, I do not think `mihomo` is a modern/standard POSIX Cli program
+    // Technically, I do not think `mihomo` is a modern/standard POSIX Cli
+    // program
     let args: Vec<String> = std::env::args()
         .map(|arg| match arg.as_str() {
             "-ext-ctl-unix" => "--ext-ctl-unix".to_string(),

--- a/clash-lib/src/app/api/handlers/config.rs
+++ b/clash-lib/src/app/api/handlers/config.rs
@@ -300,8 +300,8 @@ async fn patch_configs(
         && allow_lan != inbound_manager.get_allow_lan().await
     {
         inbound_manager.set_allow_lan(allow_lan).await;
-        // TODO: can be done with AtomicBool in each inbound manager, but requires
-        // more changes
+        // TODO: can be done with AtomicBool in each inbound manager, but
+        // requires more changes
         need_restart = true;
     }
 

--- a/clash-lib/src/app/api/handlers/utils.rs
+++ b/clash-lib/src/app/api/handlers/utils.rs
@@ -44,7 +44,8 @@ pub async fn group_url_test(
         .await;
 
     // if found active proxy, return the latency of the active proxy, otherwise
-    // return the latency of the first proxy (which is the latency of the group).
+    // return the latency of the first proxy (which is the latency of the
+    // group).
     let result = if let Some(idx) = active_idx {
         results
             .get(idx + 1)

--- a/clash-lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash-lib/src/app/dispatcher/dispatcher_impl.rs
@@ -274,7 +274,8 @@ impl Dispatcher {
 
                 // Canonicalize IPv4-mapped IPv6 addresses (e.g. SS2022 on a
                 // dual-stack socket produces ::ffff:x.x.x.x); without this
-                // new_udp_socket picks AF_INET6 with bind_addr 0.0.0.0 → EINVAL.
+                // new_udp_socket picks AF_INET6 with bind_addr 0.0.0.0 →
+                // EINVAL.
                 if let crate::session::SocksAddr::Ip(addr) = &mut packet.dst_addr {
                     *addr = addr.to_canonical();
                     sess.resolved_ip = Some(addr.ip());
@@ -294,7 +295,8 @@ impl Dispatcher {
                 // direct/mod.rs sees sess.source.is_ipv4() == false and picks
                 // bind_addr=:: while family_hint picks AF_INET for the
                 // destination — binding an AF_INET socket to [::]:0 fails with
-                // EAFNOSUPPORT (os error 97), silently dropping all UDP replies.
+                // EAFNOSUPPORT (os error 97), silently dropping all UDP
+                // replies.
                 sess.source = packet
                     .src_addr
                     .clone()
@@ -395,8 +397,10 @@ impl Dispatcher {
                         // to the logical destination (from reverse_lookup) and
                         // saves the original for src_addr restoration.
                         let rw_handle = tokio::spawn(async move {
-                            // Bound the reverse-mapping table to prevent unbounded
-                            // memory growth on long-lived sessions with many dests.
+                            // Bound the reverse-mapping table to prevent
+                            // unbounded
+                            // memory growth on long-lived sessions with many
+                            // dests.
                             const ORIG_MAP_MAX: usize = 256;
                             let mut orig_map: HashMap<SocksAddr, SocksAddr> =
                                 HashMap::new();

--- a/clash-lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash-lib/src/app/dispatcher/dispatcher_impl.rs
@@ -561,13 +561,15 @@ async fn reverse_lookup(
             } else {
                 trace!("looking up resolve cache ip: {}", socket_addr.ip());
                 match resolver.cached_for(socket_addr.ip()).await {
-                    Some(resolved) => match (resolved, socket_addr.port()).try_into() {
-                        Ok(d) => d,
-                        Err(e) => {
-                            error!("invalid domain from resolver cache: {e}");
-                            return None;
+                    Some(resolved) => {
+                        match (resolved, socket_addr.port()).try_into() {
+                            Ok(d) => d,
+                            Err(e) => {
+                                error!("invalid domain from resolver cache: {e}");
+                                return None;
+                            }
                         }
-                    },
+                    }
                     _ => (*socket_addr).into(),
                 }
             }

--- a/clash-lib/src/app/dispatcher/dispatcher_impl.rs
+++ b/clash-lib/src/app/dispatcher/dispatcher_impl.rs
@@ -543,9 +543,13 @@ async fn reverse_lookup(
                     trace!("looking up fake ip: {}", socket_addr.ip());
                     let host = resolver.reverse_lookup(ip).await;
                     match host {
-                        Some(host) => (host, socket_addr.port())
-                            .try_into()
-                            .expect("must be valid domain"),
+                        Some(host) => match (host, socket_addr.port()).try_into() {
+                            Ok(d) => d,
+                            Err(e) => {
+                                error!("invalid domain from reverse lookup: {e}");
+                                return None;
+                            }
+                        },
                         None => {
                             error!("failed to reverse lookup fake ip: {}", ip);
                             return None;
@@ -557,16 +561,26 @@ async fn reverse_lookup(
             } else {
                 trace!("looking up resolve cache ip: {}", socket_addr.ip());
                 match resolver.cached_for(socket_addr.ip()).await {
-                    Some(resolved) => (resolved, socket_addr.port())
-                        .try_into()
-                        .expect("must be valid domain"),
+                    Some(resolved) => match (resolved, socket_addr.port()).try_into() {
+                        Ok(d) => d,
+                        Err(e) => {
+                            error!("invalid domain from resolver cache: {e}");
+                            return None;
+                        }
+                    },
                     _ => (*socket_addr).into(),
                 }
             }
         }
-        crate::session::SocksAddr::Domain(host, port) => (host.to_owned(), *port)
-            .try_into()
-            .expect("must be valid domain"),
+        crate::session::SocksAddr::Domain(host, port) => {
+            match (host.to_owned(), *port).try_into() {
+                Ok(d) => d,
+                Err(e) => {
+                    error!("invalid domain in SocksAddr: {e}");
+                    return None;
+                }
+            }
+        }
     };
     Some(dst)
 }

--- a/clash-lib/src/app/dns/config.rs
+++ b/clash-lib/src/app/dns/config.rs
@@ -82,7 +82,8 @@ impl Config {
                 continue;
             }
 
-            // If the server doesn't contain a scheme, assume it's a UDP address.
+            // If the server doesn't contain a scheme, assume it's a UDP
+            // address.
             if !server.contains("://") {
                 if server.contains(':') && !server.starts_with('[') {
                     server = format!("udp://[{}]", server);
@@ -107,7 +108,8 @@ impl Config {
 
             let host = match host {
                 url::Host::Domain(v) => {
-                    // Try to parse domain as IPv4 address because of WHATWG standard
+                    // Try to parse domain as IPv4 address because of WHATWG
+                    // standard
                     match v.parse::<std::net::Ipv4Addr>() {
                         Ok(ipv4) => url::Host::Ipv4(ipv4),
                         Err(_) => url::Host::Domain(v),
@@ -365,7 +367,8 @@ impl TryFrom<&crate::config::def::Config> for Config {
                                 .as_deref()
                                 .map(parse_listen_addr)
                                 .transpose()?;
-                            // DoHConfig and DoH3Config have identical fields; helper
+                            // DoHConfig and DoH3Config have identical fields;
+                            // helper
                             // avoids duplication.
                             let map_doh_fields =
                                 |c: crate::config::def::DohListenDef| {

--- a/clash-lib/src/app/dns/filters.rs
+++ b/clash-lib/src/app/dns/filters.rs
@@ -24,10 +24,11 @@ impl GeoIPFilter {
 
 impl FallbackIPFilter for GeoIPFilter {
     fn apply(&self, ip: &net::IpAddr) -> bool {
-        // When the OnceLock is not yet populated (e.g. during startup before the
-        // MMDB is loaded) `lock.get()` returns `None`, making this return `true`
-        // — the permissive default that lets all IPs through to the fallback
-        // resolver.  Once the MMDB is set the filter behaves normally.
+        // When the OnceLock is not yet populated (e.g. during startup before
+        // the MMDB is loaded) `lock.get()` returns `None`, making this
+        // return `true` — the permissive default that lets all IPs
+        // through to the fallback resolver.  Once the MMDB is set the
+        // filter behaves normally.
         !self
             .1
             .as_ref()

--- a/clash-lib/src/app/dns/resolver/enhanced.rs
+++ b/clash-lib/src/app/dns/resolver/enhanced.rs
@@ -160,9 +160,10 @@ impl EnhancedResolver {
                 None
             };
 
-        // Build proxy server domains trie for proxy-server-nameserver resolution.
-        // This happens before the OutboundManager is fully initialized, so we can
-        // only extract domains from plain outbounds.
+        // Build proxy server domains trie for proxy-server-nameserver
+        // resolution. This happens before the OutboundManager is fully
+        // initialized, so we can only extract domains from plain
+        // outbounds.
         let plain_outbounds = outbounds.read().await;
         let proxy_server_domains = plain_outbounds
             .values()
@@ -465,8 +466,8 @@ impl EnhancedResolver {
         &self,
         message: &op::Message,
     ) -> anyhow::Result<op::Message> {
-        // Check if this is a proxy server domain, use proxy-server-nameserver if
-        // configured
+        // Check if this is a proxy server domain, use proxy-server-nameserver
+        // if configured
         if let (Some(proxy_resolver), Some(proxy_domains)) =
             (&self.proxy_resolver, &self.proxy_server_domains)
             && let Some(domain) = EnhancedResolver::domain_name_of_message(message)
@@ -1101,8 +1102,9 @@ mod tests {
         )
         .await;
 
-        // proxy_resolver is set from config; proxy_server_domains is None because
-        // no outbound handlers are registered (domains come from server_name()).
+        // proxy_resolver is set from config; proxy_server_domains is None
+        // because no outbound handlers are registered (domains come
+        // from server_name()).
         assert!(resolver.proxy_resolver.is_some());
         assert!(resolver.proxy_server_domains.is_none());
     }
@@ -1240,7 +1242,8 @@ mod tests {
         );
 
         let (config, _) = make_proxy_nameserver_config();
-        // Two domain-based proxies and one IP-based — IP should not appear in trie.
+        // Two domain-based proxies and one IP-based — IP should not appear in
+        // trie.
         let outbounds = make_outbound_registry(&[
             ("proxy-a", "proxy.example.com"),
             ("proxy-b", "vpn.example.net"),
@@ -1288,7 +1291,8 @@ mod tests {
                 .is_some()
         );
 
-        // The domain should resolve successfully through the proxy nameserver path.
+        // The domain should resolve successfully through the proxy nameserver
+        // path.
         let ip = resolver
             .resolve("one.one.one.one", false)
             .await

--- a/clash-lib/src/app/inbound/manager.rs
+++ b/clash-lib/src/app/inbound/manager.rs
@@ -208,17 +208,20 @@ impl InboundManager {
                         .remove(&provider_name)
                         .unwrap_or_default();
 
-                    // Partition new_opts: reuse or user-update existing listeners,
-                    // collect truly new opts that need a fresh listener.
+                    // Partition new_opts: reuse or user-update existing
+                    // listeners, collect truly new opts
+                    // that need a fresh listener.
                     let mut new_handles: HashMap<InboundOpts, ProviderHandleEntry> =
                         HashMap::new();
                     let mut opts_to_start: Vec<InboundOpts> = Vec::new();
 
                     for opts in new_opts {
                         if let Some(entry) = old_handles.remove(&opts) {
-                            // Structural key matched (same port/cipher/password).
-                            // Push updated user list via watch channel if present —
-                            // this avoids restarting the listener entirely.
+                            // Structural key matched (same
+                            // port/cipher/password).
+                            // Push updated user list via watch channel if
+                            // present — this avoids
+                            // restarting the listener entirely.
                             #[cfg(feature = "shadowsocks")]
                             if let (InboundOpts::Shadowsocks { users, .. }, Some(tx)) =
                                 (&opts, &entry.users_tx)
@@ -285,8 +288,9 @@ impl InboundManager {
                              '{listener_name}'"
                         );
 
-                        // For Shadowsocks, AnyTLS, and Hysteria2, create a watch
-                        // channel so future user-list updates can be pushed
+                        // For Shadowsocks, AnyTLS, and Hysteria2, create a
+                        // watch channel so future
+                        // user-list updates can be pushed
                         // without a restart.
                         #[cfg(feature = "shadowsocks")]
                         let (users_rx, users_tx) = match &opts {
@@ -377,8 +381,9 @@ impl InboundManager {
             let cancellation_token = cancellation_token.clone();
             let name = opts.common_opts().name.clone();
 
-            // For AnyTLS, Hysteria2 (and Shadowsocks), create a watch channel so
-            // user-list updates can be pushed without a full restart.
+            // For AnyTLS, Hysteria2 (and Shadowsocks), create a watch channel
+            // so user-list updates can be pushed without a full
+            // restart.
             #[cfg(feature = "shadowsocks")]
             let (users_rx, users_tx) = match opts {
                 InboundOpts::Shadowsocks { users, .. }
@@ -602,7 +607,8 @@ impl InboundManager {
         *guard = new_map;
     }
 
-    // returns true if any listener ports were changed (i.e. a restart is needed)
+    // returns true if any listener ports were changed (i.e. a restart is
+    // needed)
     pub async fn change_ports(&self, ports: Ports) -> bool {
         let mut guard = self.inbound_handlers.write().await;
 

--- a/clash-lib/src/app/inbound/network_listener.rs
+++ b/clash-lib/src/app/inbound/network_listener.rs
@@ -184,7 +184,8 @@ fn build_handler(
             users,
         } => {
             // Use the provided watch receiver, or create a static one for
-            // non-provider (static config) inbounds whose user list never changes.
+            // non-provider (static config) inbounds whose user list never
+            // changes.
             let rx = users_rx
                 .unwrap_or_else(|| tokio::sync::watch::channel(users.clone()).1);
             Some(Arc::new(ShadowsocksInbound::new(InboundOptions {

--- a/clash-lib/src/app/logging.rs
+++ b/clash-lib/src/app/logging.rs
@@ -199,12 +199,12 @@ fn setup_logging_inner(
 
     let subscriber = tracing_subscriber::registry();
 
-    // Collect and expose data about the Tokio runtime (tasks, threads, resources,
-    // etc.) — gated on tokio_unstable because console_subscriber panics at
-    // runtime if Tokio was compiled without --cfg tokio_unstable. When tests
-    // are run with RUSTFLAGS="--cfg docker_test", that env-var overrides
-    // .cargo/config.toml, so tokio_unstable is absent and the gate correctly
-    // excludes this code.
+    // Collect and expose data about the Tokio runtime (tasks, threads,
+    // resources, etc.) — gated on tokio_unstable because console_subscriber
+    // panics at runtime if Tokio was compiled without --cfg tokio_unstable.
+    // When tests are run with RUSTFLAGS="--cfg docker_test", that env-var
+    // overrides .cargo/config.toml, so tokio_unstable is absent and the
+    // gate correctly excludes this code.
     #[cfg(all(feature = "telemetry", tokio_unstable))]
     let subscriber = subscriber.with(console_subscriber::spawn());
     #[cfg(all(feature = "telemetry", tokio_unstable))]

--- a/clash-lib/src/app/remote_content_manager/mod.rs
+++ b/clash-lib/src/app/remote_content_manager/mod.rs
@@ -913,7 +913,8 @@ impl ProxyManager {
         // Extract traffic statistics from the session if available
         let traffic_stats = sess.traffic_stats.as_ref();
 
-        // Attempt intelligent pattern detection if traffic statistics are available
+        // Attempt intelligent pattern detection if traffic statistics are
+        // available
         if let Some(stats) = traffic_stats {
             let pattern = self.analyze_traffic_pattern(stats, sess).await;
 

--- a/clash-lib/src/app/remote_content_manager/providers/fetcher.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/fetcher.rs
@@ -264,7 +264,8 @@ where
                 // Accept any non-access event: macOS/Windows backends report
                 // ordinary writes as `Modify(Any)`/`Modify(Metadata)`, so a
                 // narrow filter would miss them. Over-triggering is harmless —
-                // a same-hash reload is a no-op and no longer touches the mtime.
+                // a same-hash reload is a no-op and no longer touches the
+                // mtime.
                 if matches!(event.kind, EventKind::Access(_)) {
                     return;
                 }

--- a/clash-lib/src/app/remote_content_manager/providers/inbound_provider/mod.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/inbound_provider/mod.rs
@@ -160,8 +160,8 @@ listeners:
         )
         .unwrap();
 
-        // Any unknown type in the provider file now fails the whole load at parse
-        // time.
+        // Any unknown type in the provider file now fails the whole load at
+        // parse time.
         assert!(provider.initialize().await.is_err());
     }
 

--- a/clash-lib/src/app/remote_content_manager/providers/proxy_provider/proxy_set_provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/proxy_provider/proxy_set_provider.rs
@@ -245,8 +245,9 @@ impl Provider for ProxySetProvider {
             updater(ele).await;
         }
         // Auto-watch local file providers. Best-effort: watcher setup can fail
-        // (inotify limits, unsupported filesystems), so log and keep serving the
-        // loaded proxies instead of failing init. No-op for non-file vehicles.
+        // (inotify limits, unsupported filesystems), so log and keep serving
+        // the loaded proxies instead of failing init. No-op for
+        // non-file vehicles.
         if let Err(e) = self.fetcher.start_watch().await {
             warn!(
                 "proxy provider '{}': live file watching unavailable, falling back \

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/mrs.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/mrs.rs
@@ -294,7 +294,8 @@ fn range_to_cidrs_v4(start: Ipv4Addr, end: Ipv4Addr) -> Result<Vec<IpNet>> {
     let end_u32 = u32::from(end);
 
     while current <= end_u32 {
-        // Find the largest CIDR block starting at current that fits within the range
+        // Find the largest CIDR block starting at current that fits within the
+        // range
 
         // 1. Find alignment: how many trailing zeros does current have?
         let trailing_zeros = if current == 0 {
@@ -336,7 +337,8 @@ fn range_to_cidrs_v6(start: Ipv6Addr, end: Ipv6Addr) -> Result<Vec<IpNet>> {
     let end_u128 = u128::from(end);
 
     while current <= end_u128 {
-        // Find the largest CIDR block starting at current that fits within the range
+        // Find the largest CIDR block starting at current that fits within the
+        // range
 
         // 1. Find alignment: how many trailing zeros does current have?
         let trailing_zeros = if current == 0 {
@@ -521,7 +523,8 @@ mod tests {
     fn test_range_to_cidrs_single_remaining_ip_v4() {
         // Test the edge case mentioned in Copilot comment: remaining_ips = 1
         // When we have exactly 1 IP left, leading_zeros() = 31
-        // max_block_size_bits should be 31 - 31 = 0, giving block_size = 2^0 = 1 IP
+        // max_block_size_bits should be 31 - 31 = 0, giving block_size = 2^0 =
+        // 1 IP
         let start = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100));
         let end = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)); // Same IP
         let result = range_to_cidrs(start, end).unwrap();
@@ -541,8 +544,8 @@ mod tests {
     fn test_range_to_cidrs_single_remaining_ip_v6() {
         // Test the edge case for IPv6: remaining_ips = 1
         // When we have exactly 1 IP left, leading_zeros() = 127
-        // max_block_size_bits should be 127 - 127 = 0, giving block_size = 2^0 = 1
-        // IP
+        // max_block_size_bits should be 127 - 127 = 0, giving block_size = 2^0
+        // = 1 IP
         let start = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 100));
         let end = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 100)); // Same IP
         let result = range_to_cidrs(start, end).unwrap();
@@ -561,7 +564,8 @@ mod tests {
     #[test]
     fn test_range_to_cidrs_two_remaining_ips_v4() {
         // Test remaining_ips = 2: leading_zeros() = 30
-        // max_block_size_bits should be 31 - 30 = 1, giving block_size = 2^1 = 2 IPs
+        // max_block_size_bits should be 31 - 30 = 1, giving block_size = 2^1 =
+        // 2 IPs
         let start = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100));
         let end = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101)); // 2 IPs
         let result = range_to_cidrs(start, end).unwrap();

--- a/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
+++ b/clash-lib/src/app/remote_content_manager/providers/rule_provider/provider.rs
@@ -175,8 +175,9 @@ impl RuleProviderImpl {
                             ))
                         })?;
 
-                        // Fn: we need to clone the values anyway to avoid moving
-                        // `inline_rules` from the "Environment"
+                        // Fn: we need to clone the values anyway to avoid
+                        // moving `inline_rules` from
+                        // the "Environment"
                         let mut payload =
                             inline_rules_clone.clone().unwrap_or_default();
                         payload.extend(scheme.payload);
@@ -232,8 +233,9 @@ impl RuleProviderImpl {
                                 ),
                             )));
                         }
-                        // Parse MRS format using the updated function signature.
-                        // It directly returns the required RuleContent.
+                        // Parse MRS format using the updated function
+                        // signature. It directly
+                        // returns the required RuleContent.
                         super::mrs::rules_mrs_parse(input, current_behavior)
                     }
                 }

--- a/clash-lib/src/app/router/rules/composite.rs
+++ b/clash-lib/src/app/router/rules/composite.rs
@@ -432,7 +432,8 @@ mod tests {
 
     #[test]
     fn test_nested_and_with_or() {
-        // AND with nested OR: domain=example.com AND (network=UDP OR network=TCP)
+        // AND with nested OR: domain=example.com AND (network=UDP OR
+        // network=TCP)
         let rule = CompositeRule::new(
             "AND",
             "((DOMAIN,example.com),(OR,((NETWORK,UDP),(NETWORK,TCP))))",
@@ -458,8 +459,8 @@ mod tests {
 
     #[test]
     fn test_nested_or_with_and() {
-        // OR with nested AND: (domain=a.com AND network=UDP) OR (domain=b.com AND
-        // network=TCP)
+        // OR with nested AND: (domain=a.com AND network=UDP) OR (domain=b.com
+        // AND network=TCP)
         let rule = CompositeRule::new(
             "OR",
             "((AND,((DOMAIN,a.com),(NETWORK,UDP))),(AND,((DOMAIN,b.com),(NETWORK,\

--- a/clash-lib/src/common/dashboard.rs
+++ b/clash-lib/src/common/dashboard.rs
@@ -192,9 +192,10 @@ fn extract_zip(bytes: &[u8], target_dir: &Path) -> Result<(), Error> {
         };
 
         // Strip the common prefix if present.
-        // Use the raw zip entry name (always '/' separated, platform-independent)
-        // rather than the PathBuf representation (which uses OS separators on
-        // Windows) so that prefix matching works correctly cross-platform.
+        // Use the raw zip entry name (always '/' separated,
+        // platform-independent) rather than the PathBuf representation
+        // (which uses OS separators on Windows) so that prefix matching
+        // works correctly cross-platform.
         let rel: PathBuf = match strip_prefix {
             Some(ref prefix) => {
                 let raw = file.name();
@@ -300,8 +301,9 @@ fn extract_tgz(bytes: &[u8], target_dir: &Path) -> Result<(), Error> {
             .map_err(|e| Error::InvalidConfig(format!("tgz entry path: {e}")))?
             .to_path_buf();
 
-        // Validate the *original* path before any stripping to prevent traversal
-        // attacks (e.g. an archive with `../evil` as first component).
+        // Validate the *original* path before any stripping to prevent
+        // traversal attacks (e.g. an archive with `../evil` as first
+        // component).
         if path.components().any(|c| {
             matches!(
                 c,
@@ -318,8 +320,9 @@ fn extract_tgz(bytes: &[u8], target_dir: &Path) -> Result<(), Error> {
         let rel: PathBuf = match &strip_prefix {
             Some(prefix) => {
                 // Use Path::strip_prefix to remove the common top-level dir by
-                // path component (e.g. "dist/index.html" → "index.html") without
-                // going through a string representation.
+                // path component (e.g. "dist/index.html" → "index.html")
+                // without going through a string
+                // representation.
                 let prefix_path = Path::new(prefix.trim_end_matches('/'));
                 path.strip_prefix(prefix_path)
                     .unwrap_or(&path)
@@ -437,7 +440,8 @@ mod tests {
 
     #[test]
     fn zip_no_false_prefix_match() {
-        // "dist" and "dist2" share a textual prefix but not a path-segment prefix.
+        // "dist" and "dist2" share a textual prefix but not a path-segment
+        // prefix.
         let bytes = make_zip(&[("dist/a.html", b"a"), ("dist2/b.html", b"b")]);
         let tmp = tempfile::tempdir().unwrap();
         extract_zip(&bytes, tmp.path()).unwrap();

--- a/clash-lib/src/common/io/mod.rs
+++ b/clash-lib/src/common/io/mod.rs
@@ -396,14 +396,14 @@ pub async fn copy_bidirectional(
     // zero copy is only available on linux
     #[cfg(all(target_os = "linux", feature = "zero_copy"))]
     {
-        // for zero copy, we need to track the download and upload amount with the
-        // assistance of the tracker it's somehow ugly, but i could not
-        // figure out a better way
+        // for zero copy, we need to track the download and upload amount with
+        // the assistance of the tracker it's somehow ugly, but i could
+        // not figure out a better way
         let trackers = b.trackers();
         // for socks5 & http listener, a is a raw TcpStream
         let a_raw = a.underlying_socket();
-        // for direct outbound handler **without further chains**, b is a chained
-        // stream wrapper over tcpstream
+        // for direct outbound handler **without further chains**, b is a
+        // chained stream wrapper over tcpstream
         let b_raw = b.underlying_socket();
         match (a_raw, b_raw, trackers) {
             // zero copy is only available when both streams are raw TcpStream and

--- a/clash-lib/src/common/io/splice.rs
+++ b/clash-lib/src/common/io/splice.rs
@@ -85,29 +85,32 @@ impl Pipe {
     fn new() -> Result<Self> {
         let mut pipe = std::mem::MaybeUninit::<[libc::c_int; 2]>::uninit();
         unsafe {
-            // pipe() creates a pipe, a unidirectional data channel that can be used
-            // for interprocess communication. The array pipefd is used
-            // to return two file descriptors referring to the ends of the pipe.
-            // pipefd[0] refers to the read end of the pipe.
-            // pipefd[1] refers to the write end of the pipe.
-            // Data written to the write end of the pipe is buffered by the kernel
-            // until it is read from the read end of the pipe.  For
-            // further details, see pipe(7).
+            // pipe() creates a pipe, a unidirectional data channel that can be
+            // used for interprocess communication. The array pipefd
+            // is used to return two file descriptors referring to
+            // the ends of the pipe. pipefd[0] refers to the read
+            // end of the pipe. pipefd[1] refers to the write end of
+            // the pipe. Data written to the write end of the pipe
+            // is buffered by the kernel until it is read from the
+            // read end of the pipe.  For further details, see
+            // pipe(7).
             //
             // O_DIRECT (since Linux 3.4)
-            //    Create a pipe that performs I/O in "packet" mode.  Each write(2) to
-            // the pipe is dealt with as a separate packet, and
-            //    read(2)s from the pipe will read one packet at a time.  Note the
-            // following points:    •  Writes  of  greater than PIPE_BUF
-            // bytes (see pipe(7)) will be split into multiple packets.  The constant
+            //    Create a pipe that performs I/O in "packet" mode.  Each
+            // write(2) to the pipe is dealt with as a separate
+            // packet, and    read(2)s from the pipe will read one
+            // packet at a time.  Note the following points:    •
+            // Writes  of  greater than PIPE_BUF bytes (see pipe(7))
+            // will be split into multiple packets.  The constant
             // PIPE_BUF       is defined in <limits.h>.
-            //    •  If a read(2) specifies a buffer size that is smaller than the
-            // next packet, then the requested number of bytes are
-            //       read,  and the excess bytes in the packet are discarded.
-            // Specifying a buffer size of PIPE_BUF will be sufficient
-            //       to read the largest possible packets (see the previous point).
-            //    •  Zero-length packets are not supported.  (A read(2) that
-            // specifies a buffer size of zero is a no-op,  and  returns
+            //    •  If a read(2) specifies a buffer size that is smaller than
+            // the next packet, then the requested number of bytes
+            // are       read,  and the excess bytes in the packet
+            // are discarded. Specifying a buffer size of PIPE_BUF
+            // will be sufficient       to read the largest possible
+            // packets (see the previous point).    •  Zero-length
+            // packets are not supported.  (A read(2) that specifies
+            // a buffer size of zero is a no-op,  and  returns
             //         0.)
             if libc::pipe2(
                 pipe.as_mut_ptr() as *mut libc::c_int,

--- a/clash-lib/src/common/succinct_set.rs
+++ b/clash-lib/src/common/succinct_set.rs
@@ -171,8 +171,8 @@ impl DomainSet {
         self.ranks.push(0);
         for i in 0..self.label_bit_map.len() {
             let n = self.label_bit_map[i].count_ones();
-            // Ensure ranks has enough capacity or handle potential panic if last()
-            // is called on empty vec
+            // Ensure ranks has enough capacity or handle potential panic if
+            // last() is called on empty vec
             let last_rank = self.ranks.last().copied().unwrap_or(0);
             self.ranks.push(last_rank + n as i32);
         }
@@ -191,7 +191,8 @@ impl DomainSet {
             let is_set = (self.label_bit_map[word_index] >> bit_index) & 1;
             if is_set == 1 {
                 if n & 63 == 0 {
-                    // Check if it's the start of a select block (every 64th '1' bit)
+                    // Check if it's the start of a select block (every 64th '1'
+                    // bit)
                     self.selects.push(i as i32);
                 }
                 n += 1;

--- a/clash-lib/src/common/utils.rs
+++ b/clash-lib/src/common/utils.rs
@@ -129,8 +129,9 @@ where
     P: AsRef<Path> + std::marker::Send,
 {
     debug!("downloading data from {url}");
-    // Strip URI fragment before parsing: HTTP clients must not include fragments
-    // in request-target URIs (RFC 7230 §5.3), and hyper::Uri rejects them.
+    // Strip URI fragment before parsing: HTTP clients must not include
+    // fragments in request-target URIs (RFC 7230 §5.3), and hyper::Uri
+    // rejects them.
     let url_no_fragment = url.rsplit_once('#').map(|x| x.0).unwrap_or(url);
     let url = url_no_fragment.parse::<hyper::Uri>()?;
     let mut req = http::Request::builder()

--- a/clash-lib/src/config/internal/convert/mod.rs
+++ b/clash-lib/src/config/internal/convert/mod.rs
@@ -121,8 +121,8 @@ pub(super) fn convert(mut c: def::Config) -> Result<config::Config, crate::Error
             .unwrap_or_default()
             .into_iter()
             .map(|(name, mut provider)| {
-                // `name` is `#[serde(skip)]` so it defaults to ""; populate from the
-                // map key.
+                // `name` is `#[serde(skip)]` so it defaults to ""; populate
+                // from the map key.
                 provider.set_name(name.clone());
                 (name, provider)
             })

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -313,8 +313,8 @@ pub async fn start(
         components.dns_enabled,
     ));
 
-    // api_listener is not part of components because it requires components to be
-    // initialized before it can be initialized. start it manually.
+    // api_listener is not part of components because it requires components to
+    // be initialized before it can be initialized. start it manually.
     api_listener.run_async();
 
     {
@@ -353,11 +353,12 @@ pub async fn start(
             components.stop_all();
             new_components.start_all();
 
-            // TODO: every reload is causing the API server to restart, we should
-            // make the API server reloadable instead of restarting it.
-            // maybe adding APIs to replace components
-            // and only recreate the listeners when necessary (e.g. when the listen
-            // address or port is changed)
+            // TODO: every reload is causing the API server to restart, we
+            // should make the API server reloadable instead of
+            // restarting it. maybe adding APIs to replace
+            // components and only recreate the listeners when
+            // necessary (e.g. when the listen address or port is
+            // changed)
             let new_api_listener: ArcRunner = Arc::new(app::api::ApiRunner::new(
                 controller_cfg,
                 log_tx.clone(),
@@ -497,8 +498,9 @@ async fn create_components(
     }
 
     debug!("initializing dns resolver");
-    // Clone the dns.listen for the DNS Server later before we consume the config
-    // TODO: we should separate the DNS resolver and DNS server config here
+    // Clone the dns.listen for the DNS Server later before we consume the
+    // config TODO: we should separate the DNS resolver and DNS server
+    // config here
     let dns_listen = config.dns.listen.clone();
     let dns_enable = config.dns.enable;
 

--- a/clash-lib/src/proxy/anytls/datagram.rs
+++ b/clash-lib/src/proxy/anytls/datagram.rs
@@ -208,7 +208,8 @@ impl Stream for OutboundDatagramAnytls {
                     return Poll::Ready(None);
                 }
                 // SAFETY: poll_read initialized exactly `n` bytes starting at
-                // spare_capacity_mut()[0]; advance_mut exposes them as initialized.
+                // spare_capacity_mut()[0]; advance_mut exposes them as
+                // initialized.
                 unsafe { this.packet_buf.advance_mut(n) };
 
                 if this.packet_buf.len() == packet_len {

--- a/clash-lib/src/proxy/anytls/inbound/datagram.rs
+++ b/clash-lib/src/proxy/anytls/inbound/datagram.rs
@@ -353,7 +353,8 @@ mod tests {
         );
     }
 
-    // ── Write path (Sink) ─────────────────────────────────────────────────────
+    // ── Write path (Sink)
+    // ─────────────────────────────────────────────────────
 
     /// Sending `UdpPacket { data: b"hello" }` writes `\x00\x05hello` to the
     /// inner stream.

--- a/clash-lib/src/proxy/anytls/inbound/handler.rs
+++ b/clash-lib/src/proxy/anytls/inbound/handler.rs
@@ -334,7 +334,8 @@ async fn handle_udp_session(
         }
     });
 
-    // Task B: TLS → CMD_PSH frames → relay_write (reads by InboundDatagramAnytls)
+    // Task B: TLS → CMD_PSH frames → relay_write (reads by
+    // InboundDatagramAnytls)
     tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -708,7 +709,8 @@ mod tests {
     async fn test_anytls_fallback_to_mock_generate_204() {
         install_crypto_provider();
 
-        // ── Mock backend: returns HTTP 204 (like Google generate_204) ─────────
+        // ── Mock backend: returns HTTP 204 (like Google generate_204)
+        // ─────────
         let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let backend_addr = backend_listener.local_addr().unwrap();
 
@@ -721,7 +723,8 @@ mod tests {
                 .unwrap();
         });
 
-        // ── AnyTLS inbound with fallback → mock backend ───────────────────────
+        // ── AnyTLS inbound with fallback → mock backend
+        // ───────────────────────
         let rcgen::CertifiedKey {
             cert,
             signing_key: key_pair,

--- a/clash-lib/src/proxy/direct/datagram.rs
+++ b/clash-lib/src/proxy/direct/datagram.rs
@@ -105,7 +105,8 @@ impl Sink<UdpPacket> for OutboundDatagramImpl {
 
         let dst = match &p.dst_addr {
             SocksAddr::Ip(addr) => {
-                // Explicit IP path: clear any stale DNS state from a prior packet.
+                // Explicit IP path: clear any stale DNS state from a prior
+                // packet.
                 *pending_dns = None;
                 *resolved_dst = None;
                 *addr
@@ -143,8 +144,9 @@ impl Sink<UdpPacket> for OutboundDatagramImpl {
                         })
                     });
                     let join_result = ready!(Pin::new(handle).poll(cx));
-                    // Always clear the handle once it has completed (regardless of
-                    // success or failure). If we skip this on the error path the
+                    // Always clear the handle once it has completed (regardless
+                    // of success or failure). If we skip
+                    // this on the error path the
                     // handle stays in `pending_dns` and the next call to
                     // `poll_flush` will try to poll an already-completed
                     // `JoinHandle`, which panics with "JoinHandle polled after

--- a/clash-lib/src/proxy/group/loadbalance/helpers.rs
+++ b/clash-lib/src/proxy/group/loadbalance/helpers.rs
@@ -148,8 +148,8 @@ pub fn strategy_sticky_session(proxy_manager: ProxyManager) -> StrategyFn {
                     }
                     return Ok(proxy.clone());
                 }
-                // the cached proxy is dead, change the key by a new timestamp and
-                // try again
+                // the cached proxy is dead, change the key by a new timestamp
+                // and try again
                 index = jump_hash(key + timestamp(), buckets) as usize;
             }
             // TODO: if we should just remove the key from the cache?

--- a/clash-lib/src/proxy/http/inbound/mod.rs
+++ b/clash-lib/src/proxy/http/inbound/mod.rs
@@ -78,16 +78,18 @@ impl InboundHandlerTrait for HttpInbound {
                     continue;
                 }
             };
-            let local_ip = match socket.local_addr() {
-                Ok(a) => a.ip().to_canonical(),
-                Err(e) => {
-                    warn!("http local_addr failed: {e}");
+            if !self.allow_lan {
+                let local_ip = match socket.local_addr() {
+                    Ok(a) => a.ip().to_canonical(),
+                    Err(e) => {
+                        warn!("http local_addr failed: {e}");
+                        continue;
+                    }
+                };
+                if src_addr.ip() != local_ip {
+                    warn!("Connection from {} is not allowed", src_addr);
                     continue;
                 }
-            };
-            if !self.allow_lan && src_addr.ip() != local_ip {
-                warn!("Connection from {} is not allowed", src_addr);
-                continue;
             }
 
             if let Err(e) = apply_tcp_options(&socket) {

--- a/clash-lib/src/proxy/http/inbound/mod.rs
+++ b/clash-lib/src/proxy/http/inbound/mod.rs
@@ -63,17 +63,37 @@ impl InboundHandlerTrait for HttpInbound {
         let listener = try_create_dualstack_tcplistener(self.addr)?;
 
         loop {
-            let (socket, _) = listener.accept().await?;
-            let src_addr = socket.peer_addr()?.to_canonical();
-
-            if !self.allow_lan
-                && src_addr.ip() != socket.local_addr()?.ip().to_canonical()
-            {
+            let (socket, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("http accept failed: {e}");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
+                }
+            };
+            let src_addr = match socket.peer_addr() {
+                Ok(a) => a.to_canonical(),
+                Err(e) => {
+                    warn!("http peer_addr failed: {e}");
+                    continue;
+                }
+            };
+            let local_ip = match socket.local_addr() {
+                Ok(a) => a.ip().to_canonical(),
+                Err(e) => {
+                    warn!("http local_addr failed: {e}");
+                    continue;
+                }
+            };
+            if !self.allow_lan && src_addr.ip() != local_ip {
                 warn!("Connection from {} is not allowed", src_addr);
                 continue;
             }
 
-            apply_tcp_options(&socket)?;
+            if let Err(e) = apply_tcp_options(&socket) {
+                warn!("http apply_tcp_options failed: {e}");
+                continue;
+            }
 
             let dispatcher = self.dispatcher.clone();
             let author = self.authenticator.clone();

--- a/clash-lib/src/proxy/hysteria2/codec.rs
+++ b/clash-lib/src/proxy/hysteria2/codec.rs
@@ -74,8 +74,8 @@ impl Decoder for Hy2TcpReqCodec {
         // full varint (quinn's only decode error is `UnexpectedEnd`). Since the
         // request may arrive split across QUIC reads — especially given the up
         // to 512 bytes of trailing padding — treat that as "need more bytes"
-        // (`Ok(None)`) rather than a fatal protocol error that drops the stream.
-        // Request ID
+        // (`Ok(None)`) rather than a fatal protocol error that drops the
+        // stream. Request ID
         let Ok(req_id) = VarInt::decode(&mut tmp) else {
             return Ok(None);
         };

--- a/clash-lib/src/proxy/hysteria2/outbound/mod.rs
+++ b/clash-lib/src/proxy/hysteria2/outbound/mod.rs
@@ -192,8 +192,8 @@ impl Handler {
             }
         };
 
-        // Here maybe we should use a AsyncUdpSocket which implement salamander obfs
-        // and port hopping
+        // Here maybe we should use a AsyncUdpSocket which implement salamander
+        // obfs and port hopping
         let create_socket = || async {
             new_udp_socket(
                 None,
@@ -298,8 +298,8 @@ impl Handler {
             return Err(anyhow!("auth failed: response status code {}", r.status()));
         }
 
-        // MUST have Hysteria-CC-RX and Hysteria-UDP headers according to hysteria2
-        // document
+        // MUST have Hysteria-CC-RX and Hysteria-UDP headers according to
+        // hysteria2 document
         let cc_rx = r
             .headers()
             .get("Hysteria-CC-RX")

--- a/clash-lib/src/proxy/hysteria2/udp_hop.rs
+++ b/clash-lib/src/proxy/hysteria2/udp_hop.rs
@@ -174,8 +174,8 @@ impl AsyncUdpSocket for UdpHop {
 
     //     let (_pre_conn, io) = self.get_conn();
 
-    //     // here just need change send addr, it is not necessary to change send
-    //     // contents, so we can use unsafe
+    //     // here just need change send addr, it is not necessary to change
+    // send     // contents, so we can use unsafe
     //     unsafe {
     //         let prt = transmits.as_ptr() as *mut Transmit;
     //         let slice_mut: &mut [Transmit] =

--- a/clash-lib/src/proxy/mixed/mod.rs
+++ b/clash-lib/src/proxy/mixed/mod.rs
@@ -72,16 +72,18 @@ impl InboundHandlerTrait for MixedInbound {
                     continue;
                 }
             };
-            let local_ip = match socket.local_addr() {
-                Ok(a) => a.ip().to_canonical(),
-                Err(e) => {
-                    warn!("mixed local_addr failed: {e}");
+            if !self.allow_lan {
+                let local_ip = match socket.local_addr() {
+                    Ok(a) => a.ip().to_canonical(),
+                    Err(e) => {
+                        warn!("mixed local_addr failed: {e}");
+                        continue;
+                    }
+                };
+                if src_addr.ip() != local_ip {
+                    warn!("Connection from {} is not allowed", src_addr);
                     continue;
                 }
-            };
-            if !self.allow_lan && src_addr.ip() != local_ip {
-                warn!("Connection from {} is not allowed", src_addr);
-                continue;
             }
             if let Err(e) = apply_tcp_options(&socket) {
                 warn!("mixed apply_tcp_options failed: {e}");
@@ -129,7 +131,7 @@ impl InboundHandlerTrait for MixedInbound {
                 }
 
                 _ => {
-                    let src = socket.peer_addr()?.to_canonical();
+                    let src = src_addr;
                     let dispatcher = dispatcher.clone();
                     let authenticator = authenticator.clone();
                     tokio::spawn(async move {

--- a/clash-lib/src/proxy/mixed/mod.rs
+++ b/clash-lib/src/proxy/mixed/mod.rs
@@ -72,13 +72,21 @@ impl InboundHandlerTrait for MixedInbound {
                     continue;
                 }
             };
-            if !self.allow_lan
-                && src_addr.ip() != socket.local_addr()?.ip().to_canonical()
-            {
+            let local_ip = match socket.local_addr() {
+                Ok(a) => a.ip().to_canonical(),
+                Err(e) => {
+                    warn!("mixed local_addr failed: {e}");
+                    continue;
+                }
+            };
+            if !self.allow_lan && src_addr.ip() != local_ip {
                 warn!("Connection from {} is not allowed", src_addr);
                 continue;
             }
-            apply_tcp_options(&socket)?;
+            if let Err(e) = apply_tcp_options(&socket) {
+                warn!("mixed apply_tcp_options failed: {e}");
+                continue;
+            }
 
             let mut p = [0; 1];
             let n = match socket.peek(&mut p).await {
@@ -104,7 +112,7 @@ impl InboundHandlerTrait for MixedInbound {
                 socks::SOCKS5_VERSION => {
                     let mut sess = Session {
                         network: Network::Tcp,
-                        source: socket.peer_addr()?.to_canonical(),
+                        source: src_addr,
                         so_mark: fw_mark,
                         ..Default::default()
                     };

--- a/clash-lib/src/proxy/redir/mod.rs
+++ b/clash-lib/src/proxy/redir/mod.rs
@@ -177,8 +177,8 @@ fn get_original_destination_addr(s: &TcpStream) -> io::Result<SocketAddr> {
             })?;
 
         // Convert sockaddr_storage to SocketAddr
-        Ok(target_addr.as_socket().ok_or_else(|| {
+        target_addr.as_socket().ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidInput, "not a socket address")
-        })?)
+        })
     }
 }

--- a/clash-lib/src/proxy/redir/mod.rs
+++ b/clash-lib/src/proxy/redir/mod.rs
@@ -131,8 +131,8 @@ fn get_original_destination_addr(s: &TcpStream) -> io::Result<SocketAddr> {
     unsafe {
         let (_, target_addr) =
             socket2::SockAddr::try_init(|target_addr, target_addr_len| {
-                // No sufficient method to know whether the destination IPv4 or IPv6.
-                // Follow the method in shadowsocks-libev.
+                // No sufficient method to know whether the destination IPv4 or
+                // IPv6. Follow the method in shadowsocks-libev.
 
                 let ret = libc::getsockopt(
                     fd,

--- a/clash-lib/src/proxy/redir/mod.rs
+++ b/clash-lib/src/proxy/redir/mod.rs
@@ -56,20 +56,47 @@ impl InboundHandlerTrait for RedirInbound {
         let listener = try_create_dualstack_tcplistener(self.addr)?;
 
         loop {
-            let (socket, _) = listener.accept().await?;
-            let src_addr = socket.peer_addr()?.to_canonical();
+            let (socket, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("redir accept failed: {e}");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
+                }
+            };
+            let src_addr = match socket.peer_addr() {
+                Ok(a) => a.to_canonical(),
+                Err(e) => {
+                    warn!("redir peer_addr failed: {e}");
+                    continue;
+                }
+            };
 
-            if !self.allow_lan
-                && src_addr.ip() != socket.local_addr()?.ip().to_canonical()
-            {
+            let local_ip = match socket.local_addr() {
+                Ok(a) => a.ip().to_canonical(),
+                Err(e) => {
+                    warn!("redir local_addr failed: {e}");
+                    continue;
+                }
+            };
+            if !self.allow_lan && src_addr.ip() != local_ip {
                 warn!("Connection from {} is not allowed", src_addr);
                 continue;
             }
 
-            apply_tcp_options(&socket)?;
+            if let Err(e) = apply_tcp_options(&socket) {
+                warn!("redir apply_tcp_options failed: {e}");
+                continue;
+            }
 
             // get redirect traffic original destination
-            let orig_dst = get_original_destination_addr(&socket)?.to_canonical();
+            let orig_dst = match get_original_destination_addr(&socket) {
+                Ok(a) => a.to_canonical(),
+                Err(e) => {
+                    warn!("redir get_original_destination failed: {e}");
+                    continue;
+                }
+            };
 
             let sess = Session {
                 network: Network::Tcp,
@@ -148,6 +175,8 @@ fn get_original_destination_addr(s: &TcpStream) -> io::Result<SocketAddr> {
             })?;
 
         // Convert sockaddr_storage to SocketAddr
-        Ok(target_addr.as_socket().expect("SocketAddr"))
+        Ok(target_addr.as_socket().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "not a socket address")
+        })?)
     }
 }

--- a/clash-lib/src/proxy/redir/mod.rs
+++ b/clash-lib/src/proxy/redir/mod.rs
@@ -72,16 +72,18 @@ impl InboundHandlerTrait for RedirInbound {
                 }
             };
 
-            let local_ip = match socket.local_addr() {
-                Ok(a) => a.ip().to_canonical(),
-                Err(e) => {
-                    warn!("redir local_addr failed: {e}");
+            if !self.allow_lan {
+                let local_ip = match socket.local_addr() {
+                    Ok(a) => a.ip().to_canonical(),
+                    Err(e) => {
+                        warn!("redir local_addr failed: {e}");
+                        continue;
+                    }
+                };
+                if src_addr.ip() != local_ip {
+                    warn!("Connection from {} is not allowed", src_addr);
                     continue;
                 }
-            };
-            if !self.allow_lan && src_addr.ip() != local_ip {
-                warn!("Connection from {} is not allowed", src_addr);
-                continue;
             }
 
             if let Err(e) = apply_tcp_options(&socket) {

--- a/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
+++ b/clash-lib/src/proxy/shadowsocks/inbound/datagram.rs
@@ -103,7 +103,8 @@ impl futures::Stream for InboundShadowsocksDatagram {
                     // Upsert the per-client control entry so responses to this
                     // client are encrypted with the correct uPSK and echo the
                     // correct client_session_id.  packet_id is kept per-client
-                    // for monotonic replay protection at each individual client.
+                    // for monotonic replay protection at each individual
+                    // client.
                     if let Some(ref c) = ctrl {
                         let entry =
                             client_controls.entry(src).or_insert_with(|| {
@@ -134,8 +135,9 @@ impl futures::Stream for InboundShadowsocksDatagram {
                 }
                 Err(e) => {
                     // Log the error but keep the stream alive. Without looping
-                    // here, returning Poll::Pending would leave the task without
-                    // a registered waker (the waker was consumed when data
+                    // here, returning Poll::Pending would leave the task
+                    // without a registered waker (the waker
+                    // was consumed when data
                     // arrived), permanently suspending the UDP dispatch loop.
                     error!("failed to receive udp packet: {}", e);
                     // Fall through to the next loop iteration: if the socket

--- a/clash-lib/src/proxy/socks/inbound/mod.rs
+++ b/clash-lib/src/proxy/socks/inbound/mod.rs
@@ -65,15 +65,36 @@ impl InboundHandlerTrait for SocksInbound {
         let listener = try_create_dualstack_tcplistener(self.addr)?;
 
         loop {
-            let (socket, _) = listener.accept().await?;
-            let src_addr = socket.peer_addr()?.to_canonical();
-            if !self.allow_lan
-                && src_addr.ip() != socket.local_addr()?.ip().to_canonical()
-            {
+            let (socket, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("socks accept failed: {e}");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
+                }
+            };
+            let src_addr = match socket.peer_addr() {
+                Ok(a) => a.to_canonical(),
+                Err(e) => {
+                    warn!("socks peer_addr failed: {e}");
+                    continue;
+                }
+            };
+            let local_ip = match socket.local_addr() {
+                Ok(a) => a.ip().to_canonical(),
+                Err(e) => {
+                    warn!("socks local_addr failed: {e}");
+                    continue;
+                }
+            };
+            if !self.allow_lan && src_addr.ip() != local_ip {
                 warn!("Connection from {} is not allowed", src_addr);
                 continue;
             }
-            apply_tcp_options(&socket)?;
+            if let Err(e) = apply_tcp_options(&socket) {
+                warn!("socks apply_tcp_options failed: {e}");
+                continue;
+            }
 
             let mut sess = Session {
                 network: Network::Tcp,

--- a/clash-lib/src/proxy/socks/inbound/mod.rs
+++ b/clash-lib/src/proxy/socks/inbound/mod.rs
@@ -80,16 +80,18 @@ impl InboundHandlerTrait for SocksInbound {
                     continue;
                 }
             };
-            let local_ip = match socket.local_addr() {
-                Ok(a) => a.ip().to_canonical(),
-                Err(e) => {
-                    warn!("socks local_addr failed: {e}");
+            if !self.allow_lan {
+                let local_ip = match socket.local_addr() {
+                    Ok(a) => a.ip().to_canonical(),
+                    Err(e) => {
+                        warn!("socks local_addr failed: {e}");
+                        continue;
+                    }
+                };
+                if src_addr.ip() != local_ip {
+                    warn!("Connection from {} is not allowed", src_addr);
                     continue;
                 }
-            };
-            if !self.allow_lan && src_addr.ip() != local_ip {
-                warn!("Connection from {} is not allowed", src_addr);
-                continue;
             }
             if let Err(e) = apply_tcp_options(&socket) {
                 warn!("socks apply_tcp_options failed: {e}");
@@ -99,7 +101,7 @@ impl InboundHandlerTrait for SocksInbound {
             let mut sess = Session {
                 network: Network::Tcp,
                 typ: Type::Socks5,
-                source: socket.peer_addr()?.to_canonical(),
+                source: src_addr,
                 so_mark: self.fw_mark,
 
                 ..Default::default()

--- a/clash-lib/src/proxy/ssh/mod.rs
+++ b/clash-lib/src/proxy/ssh/mod.rs
@@ -381,8 +381,8 @@ mod tests {
 
         // IMPORTANT: Container expects sshd_config at /config/sshd/sshd_config
         // Our source has it at ssh_host_keys/sshd_config, but the container
-        // startup script will ignore/delete it from there and generate a default
-        // config if /config/sshd/sshd_config doesn't exist.
+        // startup script will ignore/delete it from there and generate a
+        // default config if /config/sshd/sshd_config doesn't exist.
         // So we need to copy it to the correct location.
         let source_sshd_config = ssh_config_tmp_path
             .join("ssh_host_keys")
@@ -408,8 +408,8 @@ mod tests {
             .await?;
 
         // Generate host key pairs (ecdsa, ed25519, and rsa for test_ssh2)
-        // Note: RSA key generation doesn't need hash parameter (hash is only for
-        // signing)
+        // Note: RSA key generation doesn't need hash parameter (hash is only
+        // for signing)
         let name_and_key_pairs = [
             (
                 "ecdsa",

--- a/clash-lib/src/proxy/tproxy/mod.rs
+++ b/clash-lib/src/proxy/tproxy/mod.rs
@@ -101,7 +101,13 @@ impl InboundHandlerTrait for TproxyInbound {
             }
 
             // local_addr is getsockname
-            let orig_dst = socket.local_addr()?.to_canonical();
+            let orig_dst = match socket.local_addr() {
+                Ok(a) => a.to_canonical(),
+                Err(e) => {
+                    warn!("tproxy local_addr failed: {e}");
+                    continue;
+                }
+            };
 
             let sess = Session {
                 network: Network::Tcp,

--- a/clash-lib/src/proxy/tproxy/mod.rs
+++ b/clash-lib/src/proxy/tproxy/mod.rs
@@ -70,8 +70,21 @@ impl InboundHandlerTrait for TproxyInbound {
         let listener = TcpListener::from_std(socket.into())?;
 
         loop {
-            let (socket, _) = listener.accept().await?;
-            let src_addr = socket.peer_addr()?.to_canonical();
+            let (socket, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("tproxy accept failed: {e}");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
+                }
+            };
+            let src_addr = match socket.peer_addr() {
+                Ok(a) => a.to_canonical(),
+                Err(e) => {
+                    warn!("tproxy peer_addr failed: {e}");
+                    continue;
+                }
+            };
             // for dualstack socket src_addr may be ipv4 or ipv6;
             // tcpstream.local_addr() is the proxy destination
             // listener.local_addr() is [::]:port for dualstack
@@ -82,7 +95,10 @@ impl InboundHandlerTrait for TproxyInbound {
             // src_addr,listener.local_addr()?);     continue;
             // }
 
-            apply_tcp_options(&socket)?;
+            if let Err(e) = apply_tcp_options(&socket) {
+                warn!("tproxy apply_tcp_options failed: {e}");
+                continue;
+            }
 
             // local_addr is getsockname
             let orig_dst = socket.local_addr()?.to_canonical();
@@ -365,8 +381,20 @@ async fn handle_packet_from_dispatcher(
                 // use raw socket to send packet with custom src address
                 // This requires CAP_NET_RAW capability
                 // remote -> local
-                let src_addr = pkt.src_addr.try_into_socket_addr().unwrap();
-                let dst_addr = pkt.dst_addr.try_into_socket_addr().unwrap();
+                let src_addr = match pkt.src_addr.try_into_socket_addr() {
+                    Some(a) => a,
+                    None => {
+                        tracing::warn!("tproxy: src_addr is domain, skipping");
+                        continue;
+                    }
+                };
+                let dst_addr = match pkt.dst_addr.try_into_socket_addr() {
+                    Some(a) => a,
+                    None => {
+                        tracing::warn!("tproxy: dst_addr is domain, skipping");
+                        continue;
+                    }
+                };
                 match (src_addr, &socket_v4, &socket_v6) {
                     (SocketAddr::V4(_), Ok(socket), _) => {
                         let _ = sendto_with_src(socket, &pkt.data, dst_addr, src_addr).await

--- a/clash-lib/src/proxy/tproxy/mod.rs
+++ b/clash-lib/src/proxy/tproxy/mod.rs
@@ -309,8 +309,8 @@ async fn handle_inbound_datagram(
                     //     && let Ok(local_addr) = socket.local_addr()
                     //     && meta.addr.ip() != local_addr.ip()
                     // {
-                    //     warn!("Connection from {} is not allowed", meta.addr);
-                    //     continue;
+                    //     warn!("Connection from {} is not allowed",
+                    // meta.addr);     continue;
                     // }
                     let chunk_size = gro_chunk_size(meta.len, meta.stride);
                     if chunk_size == 0 {

--- a/clash-lib/src/proxy/transport/reality.rs
+++ b/clash-lib/src/proxy/transport/reality.rs
@@ -187,7 +187,8 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
-    // Valid params, server side dropped → TLS handshake error (not InvalidInput)
+    // Valid params, server side dropped → TLS handshake error (not
+    // InvalidInput)
     #[tokio::test]
     async fn test_handshake_error_on_closed_peer() {
         setup();

--- a/clash-lib/src/proxy/transport/shadow_tls/stream.rs
+++ b/clash-lib/src/proxy/transport/shadow_tls/stream.rs
@@ -175,8 +175,8 @@ impl<S: AsyncRead + Unpin> AsyncRead for ProxyTlsStream<S> {
                                         )
                                         .unwrap();
                                     this.read_authorized = true;
-                                    // 4. rewrite the body length to be put into the
-                                    //    read buf
+                                    // 4. rewrite the body length to be put into
+                                    //    the read buf
                                     unsafe {
                                         body.set_len(body.len() - HMAC_SIZE);
                                     }

--- a/clash-lib/src/proxy/transport/simple_obfs/http.rs
+++ b/clash-lib/src/proxy/transport/simple_obfs/http.rs
@@ -196,7 +196,8 @@ impl AsyncRead for HTTPObfs {
                     Poll::Ready(Ok(())) => {
                         let filled = tmp_buf.filled();
                         if filled.is_empty() {
-                            // Peer closed the connection before sending headers.
+                            // Peer closed the connection before sending
+                            // headers.
                             return Poll::Ready(Err(io::Error::from(
                                 io::ErrorKind::UnexpectedEof,
                             )));

--- a/clash-lib/src/proxy/tun/routes/freebsd.rs
+++ b/clash-lib/src/proxy/tun/routes/freebsd.rs
@@ -677,7 +677,8 @@ pub fn maybe_routes_clean_up(tun_cfg: &TunConfig) -> std::io::Result<()> {
     }
 
     // Drop the bypass-FIB default route(s) installed by both modes, plus the
-    // on-link host route(s) we added for the gateways (see install_bypass_default).
+    // on-link host route(s) we added for the gateways (see
+    // install_bypass_default).
     uninstall_bypass_default(bypass_fib, state.gw4.as_deref(), state.gw6.as_deref());
 
     // Reset clash's own process FIB back to 0 (no-op at shutdown, but tidy).

--- a/clash-lib/src/proxy/tun/runner.rs
+++ b/clash-lib/src/proxy/tun/runner.rs
@@ -248,6 +248,13 @@ impl TunRunner {
                     }
 
                     if !tun_visible {
+                        #[cfg(target_os = "freebsd")]
+                        if created_tun {
+                            let _ = std::process::Command::new("ifconfig")
+                                .arg(&tun_name)
+                                .arg("destroy")
+                                .output();
+                        }
                         let total_ms = TUN_VISIBILITY_MAX_ATTEMPTS as u64
                             * TUN_VISIBILITY_POLL_INTERVAL_MS;
                         let err_msg = match last_show_err {
@@ -265,7 +272,16 @@ impl TunRunner {
                     }
 
                     info!("setting up routes for tun {}", &tun_name);
-                    maybe_add_routes(cfg, &tun_name)?;
+                    if let Err(e) = maybe_add_routes(cfg, &tun_name) {
+                        #[cfg(target_os = "freebsd")]
+                        if created_tun {
+                            let _ = std::process::Command::new("ifconfig")
+                                .arg(&tun_name)
+                                .arg("destroy")
+                                .output();
+                        }
+                        return Err(e.into());
+                    }
                 } else {
                     info!("skipping route setup for existing tun {}", &tun_name);
                 }

--- a/clash-lib/src/proxy/tun/runner.rs
+++ b/clash-lib/src/proxy/tun/runner.rs
@@ -113,170 +113,172 @@ impl TunRunner {
             }
         };
 
-        let tun =
-            if let Some(fd) = tun_init_config.fd {
-                #[cfg(target_family = "unix")]
-                {
-                    info!("tun started with fd {}", fd);
-                    unsafe { tun_rs::AsyncDevice::from_fd(fd as _)? }
+        let tun = if let Some(fd) = tun_init_config.fd {
+            #[cfg(target_family = "unix")]
+            {
+                info!("tun started with fd {}", fd);
+                unsafe { tun_rs::AsyncDevice::from_fd(fd as _)? }
+            }
+
+            #[cfg(not(target_family = "unix"))]
+            {
+                return Err(Error::InvalidConfig(format!(
+                    "tun fd({fd}) is only supported on Unix-like systems"
+                )));
+            }
+        } else {
+            #[cfg(not(any(target_os = "ios", target_os = "android")))]
+            {
+                use crate::proxy::tun::routes::maybe_add_routes;
+                use network_interface::NetworkInterfaceConfig;
+                use tun_rs::DeviceBuilder;
+
+                let tun_name =
+                    tun_init_config.tun_name.expect("tun name must be provided");
+                let tun_exist = network_interface::NetworkInterface::show()
+                    .map(|ifs| ifs.into_iter().any(|x| x.name == tun_name))
+                    .unwrap_or_default();
+
+                if tun_exist {
+                    info!("tun device {} already exists, using it.", &tun_name);
+                } else {
+                    info!("tun device {} does not exist, creating.", &tun_name);
                 }
 
-                #[cfg(not(target_family = "unix"))]
-                {
-                    return Err(Error::InvalidConfig(format!(
-                        "tun fd({fd}) is only supported on Unix-like systems"
-                    )));
-                }
-            } else {
-                #[cfg(not(any(target_os = "ios", target_os = "android")))]
-                {
-                    use crate::proxy::tun::routes::maybe_add_routes;
-                    use network_interface::NetworkInterfaceConfig;
-                    use tun_rs::DeviceBuilder;
-
-                    let tun_name =
-                        tun_init_config.tun_name.expect("tun name must be provided");
-                    let tun_exist = network_interface::NetworkInterface::show()
-                        .map(|ifs| ifs.into_iter().any(|x| x.name == tun_name))
-                        .unwrap_or_default();
-
-                    if tun_exist {
-                        info!("tun device {} already exists, using it.", &tun_name);
+                let mut tun_builder = DeviceBuilder::new();
+                tun_builder = tun_builder.name(&tun_name).mtu(
+                    cfg.mtu.unwrap_or(if cfg!(windows) {
+                        65535u16
                     } else {
-                        info!("tun device {} does not exist, creating.", &tun_name);
+                        1500u16
+                    }),
+                );
+
+                if !tun_exist {
+                    debug!("setting tun ipv4 addr: {:?}", cfg.gateway);
+                    tun_builder = tun_builder.ipv4(
+                        cfg.gateway.addr(),
+                        cfg.gateway.netmask(),
+                        None,
+                    );
+
+                    if let Some(gateway_v6) = cfg.gateway_v6 {
+                        debug!("setting tun ipv6 addr: {:?}", cfg.gateway_v6);
+                        tun_builder = tun_builder
+                            .ipv6(gateway_v6.addr(), gateway_v6.netmask());
                     }
+                }
+                #[cfg(target_os = "windows")]
+                {
+                    // Use the explicitly configured GUID, or derive a
+                    // deterministic one from the device name so that the
+                    // same adapter is reused across restarts instead of
+                    // creating a new one every time.
+                    let guid = tun_init_config.guid.unwrap_or_else(|| {
+                        uuid::Uuid::new_v5(
+                            &uuid::Uuid::NAMESPACE_DNS,
+                            tun_name.as_bytes(),
+                        )
+                        .as_u128()
+                    });
+                    tun_builder = tun_builder.device_guid(guid);
+                }
 
-                    let mut tun_builder = DeviceBuilder::new();
-                    tun_builder =
-                        tun_builder.name(&tun_name).mtu(cfg.mtu.unwrap_or(
-                            if cfg!(windows) { 65535u16 } else { 1500u16 },
-                        ));
+                // FreeBSD materialises `/dev/<tun_name>` only while the
+                // network interface exists. tun-rs opens that node directly
+                // without creating the interface, so pre-create it here to
+                // avoid `open("/dev/tun0") -> ENOENT` on a fresh host.
+                #[cfg(target_os = "freebsd")]
+                let created_tun = if !tun_exist {
+                    routes::ensure_tun_device(&tun_name)?;
+                    true
+                } else {
+                    false
+                };
+                #[cfg(not(target_os = "freebsd"))]
+                let created_tun = false;
 
-                    if !tun_exist {
-                        debug!("setting tun ipv4 addr: {:?}", cfg.gateway);
-                        tun_builder = tun_builder.ipv4(
-                            cfg.gateway.addr(),
-                            cfg.gateway.netmask(),
-                            None,
-                        );
-
-                        if let Some(gateway_v6) = cfg.gateway_v6 {
-                            debug!("setting tun ipv6 addr: {:?}", cfg.gateway_v6);
-                            tun_builder = tun_builder
-                                .ipv6(gateway_v6.addr(), gateway_v6.netmask());
+                let dev = match tun_builder.build_async() {
+                    Ok(dev) => dev,
+                    Err(e) => {
+                        // If we pre-created the tun device on FreeBSD but
+                        // build_async() fails, destroy the interface so we
+                        // don't leave a dangling tun device behind.
+                        if created_tun {
+                            #[cfg(target_os = "freebsd")]
+                            {
+                                let _ = std::process::Command::new("ifconfig")
+                                    .arg(&tun_name)
+                                    .arg("destroy")
+                                    .output();
+                            }
                         }
+                        return Err(e.into());
                     }
-                    #[cfg(target_os = "windows")]
-                    {
-                        // Use the explicitly configured GUID, or derive a
-                        // deterministic one from the device name so that the
-                        // same adapter is reused across restarts instead of
-                        // creating a new one every time.
-                        let guid = tun_init_config.guid.unwrap_or_else(|| {
-                            uuid::Uuid::new_v5(
-                                &uuid::Uuid::NAMESPACE_DNS,
-                                tun_name.as_bytes(),
-                            )
-                            .as_u128()
-                        });
-                        tun_builder = tun_builder.device_guid(guid);
-                    }
+                };
 
-                    // FreeBSD materialises `/dev/<tun_name>` only while the
-                    // network interface exists. tun-rs opens that node directly
-                    // without creating the interface, so pre-create it here to
-                    // avoid `open("/dev/tun0") -> ENOENT` on a fresh host.
-                    #[cfg(target_os = "freebsd")]
-                    let created_tun = if !tun_exist {
-                        routes::ensure_tun_device(&tun_name)?;
-                        true
-                    } else {
-                        false
-                    };
-                    #[cfg(not(target_os = "freebsd"))]
-                    let created_tun = false;
-
-                    let dev = match tun_builder.build_async() {
-                        Ok(dev) => dev,
-                        Err(e) => {
-                            // If we pre-created the tun device on FreeBSD but
-                            // build_async() fails, destroy the interface so we
-                            // don't leave a dangling tun device behind.
-                            if created_tun {
-                                #[cfg(target_os = "freebsd")]
-                                {
-                                    let _ = std::process::Command::new("ifconfig")
-                                        .arg(&tun_name)
-                                        .arg("destroy")
-                                        .output();
+                if !tun_exist {
+                    // After build_async(), the new TUN interface may not be
+                    // immediately visible via NetworkInterface::show(). Poll up
+                    // to TUN_VISIBILITY_MAX_ATTEMPTS times (≈2 s) before
+                    // setting up routes, but never sleep after the final check.
+                    let mut tun_visible = false;
+                    let mut last_show_err: Option<String> = None;
+                    let mut attempt = 0u32;
+                    loop {
+                        match network_interface::NetworkInterface::show() {
+                            Ok(ifs) => {
+                                if ifs.into_iter().any(|x| x.name == tun_name) {
+                                    tun_visible = true;
+                                    break;
                                 }
                             }
-                            return Err(e.into());
-                        }
-                    };
-
-                    if !tun_exist {
-                        // After build_async(), the new TUN interface may not be
-                        // immediately visible via NetworkInterface::show(). Poll up
-                        // to TUN_VISIBILITY_MAX_ATTEMPTS times (≈2 s) before
-                        // setting up routes, but never sleep after the final check.
-                        let mut tun_visible = false;
-                        let mut last_show_err: Option<String> = None;
-                        let mut attempt = 0u32;
-                        loop {
-                            match network_interface::NetworkInterface::show() {
-                                Ok(ifs) => {
-                                    if ifs.into_iter().any(|x| x.name == tun_name) {
-                                        tun_visible = true;
-                                        break;
-                                    }
-                                }
-                                Err(e) => {
-                                    last_show_err = Some(e.to_string());
-                                }
+                            Err(e) => {
+                                last_show_err = Some(e.to_string());
                             }
-                            attempt += 1;
-                            if attempt >= TUN_VISIBILITY_MAX_ATTEMPTS {
-                                break;
-                            }
-                            tokio::time::sleep(std::time::Duration::from_millis(
-                                TUN_VISIBILITY_POLL_INTERVAL_MS,
-                            ))
-                            .await;
                         }
-
-                        if !tun_visible {
-                            let total_ms = TUN_VISIBILITY_MAX_ATTEMPTS as u64
-                                * TUN_VISIBILITY_POLL_INTERVAL_MS;
-                            let err_msg = match last_show_err {
-                                Some(e) => format!(
-                                    "tun device {} not visible after waiting {}ms \
-                                     (last error: {})",
-                                    tun_name, total_ms, e
-                                ),
-                                None => format!(
-                                    "tun device {} not visible after waiting {}ms",
-                                    tun_name, total_ms
-                                ),
-                            };
-                            return Err(Error::Operation(err_msg));
+                        attempt += 1;
+                        if attempt >= TUN_VISIBILITY_MAX_ATTEMPTS {
+                            break;
                         }
-
-                        info!("setting up routes for tun {}", &tun_name);
-                        maybe_add_routes(cfg, &tun_name)?;
-                    } else {
-                        info!("skipping route setup for existing tun {}", &tun_name);
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            TUN_VISIBILITY_POLL_INTERVAL_MS,
+                        ))
+                        .await;
                     }
 
-                    dev
+                    if !tun_visible {
+                        let total_ms = TUN_VISIBILITY_MAX_ATTEMPTS as u64
+                            * TUN_VISIBILITY_POLL_INTERVAL_MS;
+                        let err_msg = match last_show_err {
+                            Some(e) => format!(
+                                "tun device {} not visible after waiting {}ms \
+                                 (last error: {})",
+                                tun_name, total_ms, e
+                            ),
+                            None => format!(
+                                "tun device {} not visible after waiting {}ms",
+                                tun_name, total_ms
+                            ),
+                        };
+                        return Err(Error::Operation(err_msg));
+                    }
+
+                    info!("setting up routes for tun {}", &tun_name);
+                    maybe_add_routes(cfg, &tun_name)?;
+                } else {
+                    info!("skipping route setup for existing tun {}", &tun_name);
                 }
-                #[cfg(any(target_os = "ios", target_os = "android"))]
-                {
-                    return Err(Error::InvalidConfig(
-                        "only fd is supported on mobile platforms".to_string(),
-                    ));
-                }
-            };
+
+                dev
+            }
+            #[cfg(any(target_os = "ios", target_os = "android"))]
+            {
+                return Err(Error::InvalidConfig(
+                    "only fd is supported on mobile platforms".to_string(),
+                ));
+            }
+        };
 
         let (stack, tcp_listener, udp_socket) = watfaq_netstack::NetStack::new();
         Ok((tun, stack, tcp_listener, udp_socket))
@@ -333,10 +335,14 @@ impl Runner for TunRunner {
                     match pkt {
                         Ok(pkt) => {
                             if let Err(e) = tun_sink.send(pkt.into_bytes()).await {
-                                // TimedOut means the Wintun/TUN send ring buffer
-                                // was full for too long (driver backpressure). Drop
-                                // the packet and keep the runner alive — packet loss
-                                // is normal at the IP layer; TCP will retransmit and
+                                // TimedOut means the Wintun/TUN send ring
+                                // buffer
+                                // was full for too long (driver backpressure).
+                                // Drop
+                                // the packet and keep the runner alive — packet
+                                // loss
+                                // is normal at the IP layer; TCP will
+                                // retransmit and
                                 // UDP is inherently best-effort.
                                 if e.kind() == std::io::ErrorKind::TimedOut
                                     || e.kind() == std::io::ErrorKind::WouldBlock

--- a/clash-lib/src/proxy/tunnel/mod.rs
+++ b/clash-lib/src/proxy/tunnel/mod.rs
@@ -158,8 +158,8 @@ impl Sink<UdpPacket> for UdpSession {
         _cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         let this = self.deref_mut();
-        // "Back pressure" mechanism, new data is allowed to be written only when the
-        // buffer is empty
+        // "Back pressure" mechanism, new data is allowed to be written only
+        // when the buffer is empty
         match this.send_buf {
             Some(_) => Poll::Pending,
             None => Poll::Ready(Ok(())),

--- a/clash-lib/src/proxy/tunnel/mod.rs
+++ b/clash-lib/src/proxy/tunnel/mod.rs
@@ -58,11 +58,11 @@ impl TunnelInbound {
 #[async_trait]
 impl InboundHandlerTrait for TunnelInbound {
     fn handle_tcp(&self) -> bool {
-        true
+        self.network.iter().any(|n| n.eq_ignore_ascii_case("tcp"))
     }
 
     fn handle_udp(&self) -> bool {
-        true
+        self.network.iter().any(|n| n.eq_ignore_ascii_case("udp"))
     }
 
     async fn listen_tcp(&self) -> std::io::Result<()> {

--- a/clash-lib/src/proxy/tunnel/mod.rs
+++ b/clash-lib/src/proxy/tunnel/mod.rs
@@ -76,9 +76,19 @@ impl InboundHandlerTrait for TunnelInbound {
         let listener = try_create_dualstack_tcplistener(self.listen)?;
 
         loop {
-            let (socket, src_addr) = listener.accept().await?;
+            let (socket, src_addr) = match listener.accept().await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("tunnel accept failed: {e}");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
+                }
+            };
 
-            apply_tcp_options(&socket)?;
+            if let Err(e) = apply_tcp_options(&socket) {
+                warn!("tunnel apply_tcp_options failed: {e}");
+                continue;
+            }
 
             let dispatcher = self.dispatcher.clone();
             let sess = Session {

--- a/clash-lib/src/proxy/utils/shared_handler.rs
+++ b/clash-lib/src/proxy/utils/shared_handler.rs
@@ -86,9 +86,9 @@ impl OutboundHandler for SharedOutboundHandler {
 
     fn proto(&self) -> OutboundType {
         // proto() is a synchronous trait method so we cannot resolve the inner
-        // handler here. The trait documentation states this value is informational
-        // only ("do not rely on the underlying value"), so Direct is a safe
-        // placeholder.
+        // handler here. The trait documentation states this value is
+        // informational only ("do not rely on the underlying value"),
+        // so Direct is a safe placeholder.
         OutboundType::Direct
     }
 

--- a/clash-lib/src/proxy/utils/socket_helpers.rs
+++ b/clash-lib/src/proxy/utils/socket_helpers.rs
@@ -158,8 +158,9 @@ pub async fn new_udp_socket(
                 trace!(src = ?src, "udp socket bound: {socket:?}");
             }
             (None, _) => {
-                // On Windows, UDP sockets must be bound to get a valid local_addr
-                // which is required for some operations (e.g., quinn/QUIC)
+                // On Windows, UDP sockets must be bound to get a valid
+                // local_addr which is required for some
+                // operations (e.g., quinn/QUIC)
                 #[cfg(target_os = "windows")]
                 {
                     let bind_addr = match family {

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/docker_runner.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/docker_runner.rs
@@ -430,7 +430,8 @@ impl MultiDockerTestRunner {
                      error: {:?}",
                     e
                 );
-                // Cleanup all previously added containers before returning error
+                // Cleanup all previously added containers before returning
+                // error
                 for runner in std::mem::take(&mut self.runners) {
                     let _ = runner.cleanup().await;
                 }

--- a/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
+++ b/clash-lib/src/proxy/utils/test_utils/docker_utils/mod.rs
@@ -374,8 +374,8 @@ pub async fn ping_pong_test(
             }
         }
 
-        // Return the first connection error if available, otherwise return generic
-        // error
+        // Return the first connection error if available, otherwise return
+        // generic error
         if let Some(err) = first_error {
             Err(err)
         } else {

--- a/clash-lib/src/proxy/utils/test_utils/echo.rs
+++ b/clash-lib/src/proxy/utils/test_utils/echo.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/clash-lib/src/proxy/vless/stream.rs
+++ b/clash-lib/src/proxy/vless/stream.rs
@@ -113,8 +113,8 @@ impl VlessStream {
 
         debug!("VLESS waiting for response");
 
-        // Read response (VLESS response is just version + additional info length +
-        // additional info)
+        // Read response (VLESS response is just version + additional info
+        // length + additional info)
         let mut response = [0u8; 2];
         tokio::io::AsyncReadExt::read_exact(&mut self.inner, &mut response)
             .await

--- a/clash-lib/src/proxy/vless/vision.rs
+++ b/clash-lib/src/proxy/vless/vision.rs
@@ -218,8 +218,8 @@ impl AsyncRead for VisionStream {
                 continue;
             }
 
-            // 4. Need more raw bytes — read from inner into a local buffer (avoids
-            //    borrowing `this.raw` and `this.inner` simultaneously).
+            // 4. Need more raw bytes — read from inner into a local buffer
+            //    (avoids borrowing `this.raw` and `this.inner` simultaneously).
             let mut tmp = [0u8; 8192];
             let mut tmp_buf = ReadBuf::new(&mut tmp);
             match Pin::new(&mut this.inner).poll_read(cx, &mut tmp_buf) {

--- a/clash-lib/src/proxy/wg/device.rs
+++ b/clash-lib/src/proxy/wg/device.rs
@@ -704,10 +704,11 @@ impl Device for VirtualIpDevice {
                 // Some environments (NAT, checksum offload, virtualization) may
                 // corrupt the checksum We recalculate it here since
                 // WireGuard AEAD already guarantees data integrity
-                // Note: An alternative approach is to skip RX checksum verification
-                // by setting `caps.checksum.udp =
+                // Note: An alternative approach is to skip RX checksum
+                // verification by setting `caps.checksum.udp =
                 // smoltcp::phy::Checksum::Tx` in capabilities(), but
-                // recalculating feels cleaner than disabling verification entirely
+                // recalculating feels cleaner than disabling verification
+                // entirely
                 use smoltcp::wire::*;
                 if let Ok(IpVersion::Ipv4) = IpVersion::of_packet(&buffer)
                     && let Ok(ipv4) = Ipv4Packet::new_checked(&buffer[..])

--- a/clash-lib/src/session.rs
+++ b/clash-lib/src/session.rs
@@ -107,8 +107,9 @@ impl SocksAddr {
             },
             Self::Domain(domain, port) => {
                 buf.put_u8(SocksAddrType::DOMAIN);
-                buf.put_u8(domain.len() as u8);
-                buf.put_slice(domain.as_bytes());
+                let dlen = domain.len().min(255);
+                buf.put_u8(dlen as u8);
+                buf.put_slice(&domain.as_bytes()[..dlen]);
                 buf.put_u16(*port);
             }
         }

--- a/clash-lib/src/session.rs
+++ b/clash-lib/src/session.rs
@@ -107,7 +107,7 @@ impl SocksAddr {
             },
             Self::Domain(domain, port) => {
                 buf.put_u8(SocksAddrType::DOMAIN);
-                let dlen = domain.len().min(255);
+                let dlen = domain.floor_char_boundary(255);
                 buf.put_u8(dlen as u8);
                 buf.put_slice(&domain.as_bytes()[..dlen]);
                 buf.put_u16(*port);

--- a/clash-lib/tests/api_tests.rs
+++ b/clash-lib/tests/api_tests.rs
@@ -177,7 +177,8 @@ async fn test_config_reload_via_payload() {
     let wd =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/config/client");
 
-    // Allocate 8 ports: 7 for the initial instance + 1 for the reloaded controller
+    // Allocate 8 ports: 7 for the initial instance + 1 for the reloaded
+    // controller
     let port_base = alloc_ports(8);
     let config_str = make_client_config_str(port_base);
 

--- a/clash-lib/tests/integration_tests.rs
+++ b/clash-lib/tests/integration_tests.rs
@@ -211,7 +211,8 @@ async fn integration_test_anytls_udp() {
     let server_config = wd_server.join("server_anytls.yaml");
     let client_config = wd_client.join("rules_anytls.yaml");
 
-    // ── UDP echo server ───────────────────────────────────────────────────────
+    // ── UDP echo server
+    // ───────────────────────────────────────────────────────
     let echo_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let echo_addr: SocketAddr = echo_sock.local_addr().unwrap();
     tokio::spawn(async move {
@@ -221,9 +222,10 @@ async fn integration_test_anytls_udp() {
         echo_sock.send_to(&buf[..n], peer).await.unwrap();
     });
 
-    // ── Start clash server and client ─────────────────────────────────────────
-    // Use ClashInstance so server/client are properly shut down when the test
-    // ends, releasing ports 8902/9092 and 8998/9095 for subsequent tests.
+    // ── Start clash server and client
+    // ───────────────────────────────────────── Use ClashInstance so
+    // server/client are properly shut down when the test ends, releasing
+    // ports 8902/9092 and 8998/9095 for subsequent tests.
     let _server = ClashInstance::start(
         Options {
             config: Config::File(server_config.to_string_lossy().to_string()),
@@ -248,7 +250,8 @@ async fn integration_test_anytls_udp() {
     )
     .expect("Failed to start AnyTLS client");
 
-    // ── SOCKS5 UDP ASSOCIATE handshake ────────────────────────────────────────
+    // ── SOCKS5 UDP ASSOCIATE handshake
+    // ────────────────────────────────────────
     let mut tcp = tokio::net::TcpStream::connect("127.0.0.1:8998")
         .await
         .unwrap();
@@ -281,8 +284,9 @@ async fn integration_test_anytls_udp() {
         _ => panic!("unexpected ATYP {atyp} in UDP ASSOCIATE reply"),
     };
 
-    // ── Send a UDP datagram through the relay ─────────────────────────────────
-    // SOCKS5 UDP header: RSV(2) | FRAG(1) | ATYP(1) | DST_ADDR | DST_PORT | DATA
+    // ── Send a UDP datagram through the relay
+    // ───────────────────────────────── SOCKS5 UDP header: RSV(2) | FRAG(1)
+    // | ATYP(1) | DST_ADDR | DST_PORT | DATA
     let payload = b"hello-udp-anytls";
     let echo_ip = match echo_addr.ip() {
         std::net::IpAddr::V4(v4) => v4.octets(),
@@ -299,7 +303,8 @@ async fn integration_test_anytls_udp() {
     let client_sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     client_sock.send_to(&dgram, relay_addr).await.unwrap();
 
-    // ── Receive the echoed datagram ───────────────────────────────────────────
+    // ── Receive the echoed datagram
+    // ───────────────────────────────────────────
     let mut recv_buf = vec![0u8; 4096];
     let (n, _) = tokio::time::timeout(
         std::time::Duration::from_secs(5),

--- a/clash-netstack/examples/netstack_lwip.rs
+++ b/clash-netstack/examples/netstack_lwip.rs
@@ -90,9 +90,10 @@ mod macos {
         #[cfg(target_os = "macos")]
         {
             // This function is used to add test routes for the TUN device.
-            // The actual implementation will depend on your system and requirements.
-            // For example, you might use `route` command on Unix-like systems.
-            // Here we assume the route is already added in the example description.
+            // The actual implementation will depend on your system and
+            // requirements. For example, you might use `route`
+            // command on Unix-like systems. Here we assume the
+            // route is already added in the example description.
             let output = std::process::Command::new("route")
                 .arg("add")
                 .arg("-host")

--- a/clash-netstack/examples/netstack_smoltcp.rs
+++ b/clash-netstack/examples/netstack_smoltcp.rs
@@ -90,9 +90,10 @@ mod macos {
         #[cfg(target_os = "macos")]
         {
             // This function is used to add test routes for the TUN device.
-            // The actual implementation will depend on your system and requirements.
-            // For example, you might use `route` command on Unix-like systems.
-            // Here we assume the route is already added in the example description.
+            // The actual implementation will depend on your system and
+            // requirements. For example, you might use `route`
+            // command on Unix-like systems. Here we assume the
+            // route is already added in the example description.
             let output = std::process::Command::new("route")
                 .arg("add")
                 .arg("-host")

--- a/clash-netstack/examples/with_tun_rs.rs
+++ b/clash-netstack/examples/with_tun_rs.rs
@@ -135,9 +135,10 @@ mod macos {
         #[cfg(target_os = "macos")]
         {
             // This function is used to add test routes for the TUN device.
-            // The actual implementation will depend on your system and requirements.
-            // For example, you might use `route` command on Unix-like systems.
-            // Here we assume the route is already added in the example description.
+            // The actual implementation will depend on your system and
+            // requirements. For example, you might use `route`
+            // command on Unix-like systems. Here we assume the
+            // route is already added in the example description.
             let output = std::process::Command::new("route")
                 .arg("add")
                 .arg("-host")

--- a/clash-netstack/src/device.rs
+++ b/clash-netstack/src/device.rs
@@ -50,8 +50,9 @@ impl Device for NetstackDevice {
     ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         // Reserve a tx slot FIRST before touching rx_queue.
         // If we checked rx_queue first, a successful try_recv() would consume
-        // the inbound packet even when try_reserve() subsequently fails, silently
-        // dropping ACKs and preventing smoltcp from advancing its send window.
+        // the inbound packet even when try_reserve() subsequently fails,
+        // silently dropping ACKs and preventing smoltcp from advancing
+        // its send window.
         let permit = self.tx_sender.try_reserve().ok()?;
         let packet = self.rx_queue.try_recv().ok()?;
 

--- a/clash-netstack/src/stack.rs
+++ b/clash-netstack/src/stack.rs
@@ -111,8 +111,8 @@ impl NetStack {
         let (udp_inbound_app, udp_outbound_stack) =
             mpsc::unbounded_channel::<Packet>();
 
-        // this UdpSocket is essentially an Iface for UDP but much simpler as it only
-        // does packets forwarding
+        // this UdpSocket is essentially an Iface for UDP but much simpler as it
+        // only does packets forwarding
         let udp_socket = UdpSocket::new(udp_outbound_stack, udp_packet_sender);
         let (tcp_inbound_app, tcp_outbound_stack) =
             mpsc::unbounded_channel::<Packet>();

--- a/clash-netstack/src/tcp_listener.rs
+++ b/clash-netstack/src/tcp_listener.rs
@@ -373,18 +373,21 @@ impl TcpListener {
             if should_poll_now {
                 trace!("Woke up to poll sockets");
 
-                // Drain any pending notifier events before calling iface.poll().
+                // Drain any pending notifier events before calling
+                // iface.poll().
                 //
-                // The critical case is IfaceEvent::TcpStream: poll_packets creates
-                // a smoltcp socket and queues it here *before* injecting the raw SYN
-                // packet into the device buffer.  If iface.poll() runs before the
-                // socket is added to the SocketSet, smoltcp sees the SYN with no
-                // matching listener and sends RST — immediately failing the
-                // connection.
+                // The critical case is IfaceEvent::TcpStream: poll_packets
+                // creates a smoltcp socket and queues it here
+                // *before* injecting the raw SYN packet into
+                // the device buffer.  If iface.poll() runs before the
+                // socket is added to the SocketSet, smoltcp sees the SYN with
+                // no matching listener and sends RST —
+                // immediately failing the connection.
                 //
-                // During active downloads poll_delay often returns 0/None, keeping
-                // should_poll_now=true and never entering the else branch below.
-                // Draining here ensures sockets are always registered in time.
+                // During active downloads poll_delay often returns 0/None,
+                // keeping should_poll_now=true and never
+                // entering the else branch below. Draining here
+                // ensures sockets are always registered in time.
                 loop {
                     match notifier_rx.try_recv() {
                         Ok(IfaceEvent::TcpStream(stream)) => {
@@ -549,8 +552,9 @@ impl TcpListener {
                 // StackSplitStream draining the tx packet channel) get a chance
                 // to run between iface.poll() calls.  Without this yield, a
                 // sustained smoltcp poll_delay == ZERO response (which occurs
-                // whenever packets are waiting to be transmitted) creates a tight
-                // synchronous loop that starves StackSplitStream, preventing the
+                // whenever packets are waiting to be transmitted) creates a
+                // tight synchronous loop that starves
+                // StackSplitStream, preventing the
                 // consumer from receiving data and sending ACKs back.  That
                 // starvation fills smoltcp's send window and triggers RTO.
                 tokio::task::yield_now().await;

--- a/clash-netstack/src/tcp_stream.rs
+++ b/clash-netstack/src/tcp_stream.rs
@@ -25,7 +25,8 @@ impl Drop for TcpStream {
         );
 
         // socket_dropped tells poll_sockets to drain send_buffer and issue FIN.
-        // read_closed / write_closed unblock any concurrent poll_read / poll_write.
+        // read_closed / write_closed unblock any concurrent poll_read /
+        // poll_write.
         self.handle.socket_dropped.store(true, Ordering::Release);
         self.handle.read_closed.store(true, Ordering::Release);
         self.handle.write_closed.store(true, Ordering::Release);
@@ -139,9 +140,10 @@ impl tokio::io::AsyncWrite for TcpStream {
 
         if send_buf.is_full() {
             // Register waker FIRST, then re-check to close the TOCTOU window.
-            // If poll_sockets drains the buffer between is_full() and register(),
-            // wake() is a no-op (no waker stored). The re-check below detects
-            // the buffer is now non-full and falls through to enqueue data.
+            // If poll_sockets drains the buffer between is_full() and
+            // register(), wake() is a no-op (no waker stored). The
+            // re-check below detects the buffer is now non-full and
+            // falls through to enqueue data.
             self.handle.send_waker.register(cx.waker());
             if send_buf.is_full() {
                 trace!(

--- a/clash-netstack/tests/integration_test.rs
+++ b/clash-netstack/tests/integration_test.rs
@@ -85,8 +85,9 @@ async fn test_speedtest_bulk_download() {
     });
 
     // Client simulation task: performs the TCP handshake, reads data segments
-    // from StackSplitStream, and sends cumulative ACKs back through the mock TUN.
-    // Spawned BEFORE awaiting tcp_listener so its SYN is in-flight while we wait.
+    // from StackSplitStream, and sends cumulative ACKs back through the mock
+    // TUN. Spawned BEFORE awaiting tcp_listener so its SYN is in-flight
+    // while we wait.
     let client = tokio::spawn(async move {
         // --- TCP handshake: SYN → SYN-ACK → ACK ---
         tun_in.send(build_tcp_syn_packet()).unwrap();
@@ -170,11 +171,11 @@ async fn test_speedtest_bulk_download() {
         received
     });
 
-    // Await the TcpStream HERE (in the main test body), NOT inside the relay task.
-    // This keeps tcp_listener alive until after join!() completes, preventing
-    // TcpListener::Drop from aborting the netstack task while data is still
-    // in-flight. The client task already sent the SYN concurrently above, so
-    // next() returns quickly.
+    // Await the TcpStream HERE (in the main test body), NOT inside the relay
+    // task. This keeps tcp_listener alive until after join!() completes,
+    // preventing TcpListener::Drop from aborting the netstack task while
+    // data is still in-flight. The client task already sent the SYN
+    // concurrently above, so next() returns quickly.
     let stream = tcp_listener.next().await.expect("no TcpStream");
 
     // Relay task: writes TRANSFER_BYTES into the TcpStream.
@@ -267,9 +268,9 @@ async fn test_new_connection_during_active_transfer() {
     let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
     let tun_in2 = tun_in.clone();
 
-    // Client 1 (port 1024): handshake + receive CONN1_BYTES, ACKing each segment.
-    // Fires `ready_tx` as soon as the first data segment arrives (smoltcp
-    // hot-path).
+    // Client 1 (port 1024): handshake + receive CONN1_BYTES, ACKing each
+    // segment. Fires `ready_tx` as soon as the first data segment arrives
+    // (smoltcp hot-path).
     let client1 = tokio::spawn(async move {
         tun_in.send(build_tcp_syn_packet()).unwrap();
 


### PR DESCRIPTION
### Summary
- Restarts inbound TCP/UDP listeners on accept failure after a 1s backoff instead of terminating permanently.
- Tolerates per-connection errors across HTTP, Mixed, Redir, SOCKS, TProxy, and Tunnel listeners.
- Replaces panicking `expect()` in `reverse_lookup` and `SocksAddr` with error propagation.
- Clamps domain lengths to 255 bytes in `SocksAddr` serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network listeners recover automatically from connection and listener errors instead of stopping.
  * Malformed addresses and DNS values are handled safely without crashes.
  * Improved resilience across HTTP, SOCKS, TProxy, tunnel, mixed, and redirect connections.
  * Oversized SOCKS5 domain names are safely limited to the supported protocol length.

* **Improvements**
  * Hysteria2 inbound user-list updates apply without restarting listeners.
  * TUN initialization and interface setup are more reliable across supported platforms.
  * Tunnel modes now respect configured TCP and UDP network options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->