### PR TITLE
fix(transport): datagram stream framing and partial I/O handling

### DIFF
--- a/clash-lib/src/proxy/transport/grpc.rs
+++ b/clash-lib/src/proxy/transport/grpc.rs
@@ -196,17 +196,18 @@ impl AsyncRead for GrpcStream {
             let to_read = std::cmp::min(buf.remaining(), self.payload_len);
             let to_read = std::cmp::min(to_read, self.buffer.len());
 
-            if to_read == 0 {
-                assert!(buf.remaining() > 0);
+            if to_read > 0 {
+                let data = self.buffer.split_to(to_read);
 
-                return Poll::Pending;
+                self.payload_len -= to_read;
+                buf.put_slice(&data[..]);
+                return Poll::Ready(Ok(()));
             }
-
-            let data = self.buffer.split_to(to_read);
-
-            self.payload_len -= to_read;
-            buf.put_slice(&data[..]);
-            return Poll::Ready(Ok(()));
+            // to_read == 0 (buf.remaining() > 0 per AsyncRead contract):
+            // we parsed the gRPC/protobuf header but the payload hasn't
+            // arrived in the buffer yet.  Fall through to poll_data below
+            // so the waker gets registered.  Returning Poll::Pending here
+            // without registering a waker would deadlock the task forever.
         }
 
         match ready!(Pin::new(&mut recv.as_mut().unwrap()).poll_data(cx)) {

--- a/clash-lib/src/proxy/transport/shadow_tls/stream.rs
+++ b/clash-lib/src/proxy/transport/shadow_tls/stream.rs
@@ -344,6 +344,15 @@ impl<S: AsyncRead + Unpin> AsyncRead for VerifiedStream<S> {
                                 "appdata verify failed",
                             )));
                         }
+                    } else {
+                        // Non-APPLICATION_DATA records (e.g. handshake,
+                        // alert, change-cipher-spec) are unexpected after
+                        // verification.  Skip this record and read the next
+                        // header.  Without this state transition the loop
+                        // would re-enter WaitingData with the same size and
+                        // consume bytes belonging to the next TLS record,
+                        // silently corrupting the stream.
+                        this.read_state = ReadState::WaitingHeader;
                     }
                 }
                 ReadState::FlushingData => {

--- a/clash-lib/src/proxy/trojan/datagram.rs
+++ b/clash-lib/src/proxy/trojan/datagram.rs
@@ -106,6 +106,16 @@ impl Sink<UdpPacket> for OutboundDatagramTrojan {
 
             while !payload.is_empty() {
                 let n = ready!(inner.as_mut().poll_write(cx, payload.as_ref()))?;
+                if n == 0 {
+                    // poll_write returning Ok(0) means the stream is closed
+                    // (per AsyncWrite contract). Without this check, the loop
+                    // would spin forever since payload.advance(0) makes no
+                    // progress. Mirror std::io::Write::write_all behavior.
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write whole trojan udp packet: stream closed",
+                    )));
+                }
                 *written.as_mut().unwrap() += n;
                 payload.advance(n);
 

--- a/clash-lib/src/proxy/trojan/datagram.rs
+++ b/clash-lib/src/proxy/trojan/datagram.rs
@@ -100,7 +100,9 @@ impl Sink<UdpPacket> for OutboundDatagramTrojan {
             payload.put_slice(b"\r\n");
             payload.put_slice(data);
 
-            if written.is_none() {
+            if let Some(w) = *written {
+                payload.advance(w);
+            } else {
                 *written = Some(0);
             }
 
@@ -111,6 +113,8 @@ impl Sink<UdpPacket> for OutboundDatagramTrojan {
                     // (per AsyncWrite contract). Without this check, the loop
                     // would spin forever since payload.advance(0) makes no
                     // progress. Mirror std::io::Write::write_all behavior.
+                    *pkt_container = None;
+                    *written = None;
                     return Poll::Ready(Err(io::Error::new(
                         io::ErrorKind::WriteZero,
                         "failed to write whole trojan udp packet: stream closed",
@@ -394,5 +398,108 @@ impl Stream for OutboundDatagramTrojan {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    use futures::{SinkExt, StreamExt};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+    use super::*;
+
+    struct ChunkedStream {
+        buf: Vec<u8>,
+        chunk_size: usize,
+    }
+
+    impl AsyncWrite for ChunkedStream {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let to_write = std::cmp::min(buf.len(), self.chunk_size);
+            self.buf.extend_from_slice(&buf[..to_write]);
+            Poll::Ready(Ok(to_write))
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncRead for ChunkedStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    impl crate::proxy::ProxyStream for ChunkedStream {}
+
+    #[tokio::test]
+    async fn test_trojan_datagram_sink_partial_writes() {
+        let stream: AnyStream = Box::new(ChunkedStream {
+            buf: Vec::new(),
+            chunk_size: 3,
+        });
+        let remote_addr: SocksAddr = "1.1.1.1:443".parse().unwrap();
+        let mut sink = OutboundDatagramTrojan::new(stream, remote_addr.clone());
+
+        let dst_addr: SocksAddr = "8.8.8.8:53".parse().unwrap();
+        let payload = b"hello trojan udp payload with enough length";
+        let packet = UdpPacket {
+            data: payload.to_vec(),
+            src_addr: remote_addr.clone(),
+            dst_addr: dst_addr.clone(),
+            inbound_user: None,
+        };
+
+        sink.send(packet).await.expect("send must succeed");
+    }
+
+    #[tokio::test]
+    async fn test_trojan_datagram_roundtrip() {
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let remote_addr: SocksAddr = "1.1.1.1:443".parse().unwrap();
+        let mut client =
+            OutboundDatagramTrojan::new(Box::new(client_io), remote_addr.clone());
+        let mut server =
+            OutboundDatagramTrojan::new(Box::new(server_io), remote_addr.clone());
+
+        let dst_addr: SocksAddr = "8.8.8.8:53".parse().unwrap();
+        let test_payload = b"roundtrip trojan udp packet data";
+        let packet = UdpPacket {
+            data: test_payload.to_vec(),
+            src_addr: remote_addr.clone(),
+            dst_addr: dst_addr.clone(),
+            inbound_user: None,
+        };
+
+        client.send(packet).await.expect("send should succeed");
+
+        let received = server.next().await.expect("should receive packet");
+        assert_eq!(received.data, test_payload);
+        assert_eq!(received.dst_addr, dst_addr);
+        assert_eq!(received.src_addr, remote_addr);
     }
 }

--- a/clash-lib/src/proxy/vless/datagram.rs
+++ b/clash-lib/src/proxy/vless/datagram.rs
@@ -25,9 +25,10 @@ pub struct OutboundDatagramVless {
     pending_packet: Option<UdpPacket>,
 
     // Read state
-    read_buf: Vec<u8>,
+    packet_buf: BytesMut,
     remaining_bytes: usize,
     length_buf: [u8; 2],
+    header_read: usize,
 
     // State tracking
     flushed: bool,
@@ -40,9 +41,10 @@ impl OutboundDatagramVless {
             remote_addr,
             write_buf: BytesMut::new(),
             pending_packet: None,
-            read_buf: vec![0u8; 65536],
+            packet_buf: BytesMut::new(),
             remaining_bytes: 0,
             length_buf: [0; 2],
+            header_read: 0,
             flushed: true,
         }
     }
@@ -185,75 +187,95 @@ impl Stream for OutboundDatagramVless {
         let mut inner = Pin::new(&mut this.inner);
 
         loop {
-            // If we have remaining bytes from a previous packet, read them
-            if this.remaining_bytes > 0 {
-                let to_read =
-                    std::cmp::min(this.remaining_bytes, this.read_buf.len());
-                let mut read_buf = ReadBuf::new(&mut this.read_buf[..to_read]);
-
-                match ready!(inner.as_mut().poll_read(cx, &mut read_buf)) {
+            // Phase 1: read the 2-byte length header.  TCP may deliver a
+            // single byte at a time, so we must accumulate until both bytes
+            // are available.  The previous code treated a 1-byte read as
+            // "incomplete" and returned EOF, prematurely closing the stream.
+            if this.remaining_bytes == 0 && this.header_read < 2 {
+                let mut header_read_buf =
+                    ReadBuf::new(&mut this.length_buf[this.header_read..]);
+                match ready!(inner.as_mut().poll_read(cx, &mut header_read_buf)) {
                     Ok(()) => {
-                        let data = read_buf.filled();
-                        if data.is_empty() {
-                            return Poll::Ready(None); // Connection closed
+                        let n = header_read_buf.filled().len();
+                        if n == 0 {
+                            return Poll::Ready(None); // connection closed
+                        }
+                        this.header_read += n;
+                        if this.header_read < 2 {
+                            continue; // need the second header byte
                         }
 
-                        this.remaining_bytes -= data.len();
+                        let packet_len =
+                            u16::from_be_bytes(this.length_buf) as usize;
+                        this.header_read = 0;
 
+                        if packet_len == 0 {
+                            trace!("received empty packet");
+                            continue; // skip empty packets
+                        }
+
+                        if packet_len > MAX_PACKET_LENGTH {
+                            debug!("packet too large: {} bytes", packet_len);
+                            return Poll::Ready(None);
+                        }
+
+                        this.remaining_bytes = packet_len;
+                        this.packet_buf.clear();
+                        this.packet_buf.reserve(packet_len);
                         trace!(
-                            "received VLESS UDP packet chunk, len={}, remaining={}",
-                            data.len(),
-                            this.remaining_bytes
+                            "expecting VLESS UDP packet of {} bytes",
+                            packet_len
                         );
-
-                        return Poll::Ready(Some(UdpPacket {
-                            data: data.to_vec(),
-                            src_addr: this.remote_addr.clone(),
-                            dst_addr: this.remote_addr.clone(),
-                            inbound_user: None,
-                        }));
                     }
                     Err(e) => {
-                        debug!("failed to read packet data: {}", e);
+                        debug!("failed to read length header: {}", e);
                         return Poll::Ready(None);
                     }
                 }
             }
 
-            // Read the 2-byte length header
-            let mut length_read_buf = ReadBuf::new(&mut this.length_buf);
-            match ready!(inner.as_mut().poll_read(cx, &mut length_read_buf)) {
-                Ok(()) => {
-                    let data = length_read_buf.filled();
-                    if data.len() < 2 {
-                        if data.is_empty() {
-                            return Poll::Ready(None); // Connection closed
+            // Phase 2: read the packet payload.  TCP may deliver it in
+            // multiple chunks; we must accumulate until the full packet is
+            // received before returning it.  The previous code returned a
+            // UdpPacket for every poll_read call, splitting a single VLESS
+            // UDP packet into multiple items and corrupting the data stream.
+            if this.remaining_bytes > 0 {
+                let remaining = this.remaining_bytes - this.packet_buf.len();
+                let n = {
+                    let spare = this.packet_buf.spare_capacity_mut();
+                    let mut read_buf = ReadBuf::uninit(&mut spare[..remaining]);
+                    match inner.as_mut().poll_read(cx, &mut read_buf) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => {
+                            debug!("failed to read packet data: {}", e);
+                            return Poll::Ready(None);
                         }
-                        debug!("incomplete length header: {} bytes", data.len());
-                        return Poll::Ready(None);
+                        Poll::Ready(Ok(())) => read_buf.filled().len(),
                     }
-
-                    let packet_len = u16::from_be_bytes([data[0], data[1]]) as usize;
-
-                    if packet_len == 0 {
-                        trace!("received empty packet");
-                        continue; // Skip empty packets
-                    }
-
-                    if packet_len > MAX_PACKET_LENGTH {
-                        debug!("packet too large: {} bytes", packet_len);
-                        return Poll::Ready(None);
-                    }
-
-                    // Set up to read the packet data
-                    this.remaining_bytes = packet_len;
-
-                    trace!("expecting VLESS UDP packet of {} bytes", packet_len);
+                };
+                if n == 0 {
+                    return Poll::Ready(None); // connection closed
                 }
-                Err(e) => {
-                    debug!("failed to read length header: {}", e);
-                    return Poll::Ready(None);
+                // SAFETY: poll_read initialized exactly n bytes starting at
+                // the beginning of the spare capacity.
+                unsafe { this.packet_buf.advance_mut(n) };
+
+                if this.packet_buf.len() == this.remaining_bytes {
+                    let data =
+                        this.packet_buf.split_to(this.remaining_bytes).to_vec();
+                    this.remaining_bytes = 0;
+                    trace!(
+                        "received complete VLESS UDP packet, len={}",
+                        data.len()
+                    );
+                    return Poll::Ready(Some(UdpPacket {
+                        data,
+                        src_addr: this.remote_addr.clone(),
+                        dst_addr: this.remote_addr.clone(),
+                        inbound_user: None,
+                    }));
                 }
+                // Partial read: loop and continue accumulating.
             }
         }
     }

--- a/clash-lib/src/proxy/vless/datagram.rs
+++ b/clash-lib/src/proxy/vless/datagram.rs
@@ -222,10 +222,7 @@ impl Stream for OutboundDatagramVless {
                         this.remaining_bytes = packet_len;
                         this.packet_buf.clear();
                         this.packet_buf.reserve(packet_len);
-                        trace!(
-                            "expecting VLESS UDP packet of {} bytes",
-                            packet_len
-                        );
+                        trace!("expecting VLESS UDP packet of {} bytes", packet_len);
                     }
                     Err(e) => {
                         debug!("failed to read length header: {}", e);
@@ -264,10 +261,7 @@ impl Stream for OutboundDatagramVless {
                     let data =
                         this.packet_buf.split_to(this.remaining_bytes).to_vec();
                     this.remaining_bytes = 0;
-                    trace!(
-                        "received complete VLESS UDP packet, len={}",
-                        data.len()
-                    );
+                    trace!("received complete VLESS UDP packet, len={}", data.len());
                     return Poll::Ready(Some(UdpPacket {
                         data,
                         src_addr: this.remote_addr.clone(),

--- a/clash-lib/src/proxy/vmess/vmess_impl/datagram.rs
+++ b/clash-lib/src/proxy/vmess/vmess_impl/datagram.rs
@@ -104,9 +104,9 @@ impl Sink<UdpPacket> for OutboundDatagramVmess {
             }
             let written_val = written.as_mut().unwrap();
             while *written_val < pkt.data.len() {
-                let n = ready!(inner
-                    .as_mut()
-                    .poll_write(cx, &pkt.data[*written_val..]))?;
+                let n = ready!(
+                    inner.as_mut().poll_write(cx, &pkt.data[*written_val..])
+                )?;
                 if n == 0 {
                     *pkt_container = None;
                     *written = None;

--- a/clash-lib/src/proxy/vmess/vmess_impl/datagram.rs
+++ b/clash-lib/src/proxy/vmess/vmess_impl/datagram.rs
@@ -6,7 +6,6 @@ use tracing::{debug, error, instrument};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::{
-    common::errors::new_io_error,
     proxy::{AnyStream, datagram::UdpPacket},
     session::SocksAddr,
 };
@@ -94,15 +93,40 @@ impl Sink<UdpPacket> for OutboundDatagramVmess {
                 )));
             }
 
+            // Loop until the entire payload is written.  TCP streams may
+            // accept fewer bytes than requested (partial write), and the
+            // previous single-shot poll_write returned an error in that case,
+            // causing intermittent UDP packet loss.  Also guard against
+            // poll_write returning Ok(0) (closed stream) to avoid an infinite
+            // loop.
             if written.is_none() {
-                let n = ready!(inner.as_mut().poll_write(cx, pkt.data.as_ref()))?;
-                debug!(
-                    "send udp packet to remote vmess server, len: {}, remote_addr: \
-                     {}, dst_addr: {}",
-                    n, remote_addr, pkt.dst_addr
-                );
-                *written = Some(n);
+                *written = Some(0);
             }
+            let written_val = written.as_mut().unwrap();
+            while *written_val < pkt.data.len() {
+                let n = ready!(inner
+                    .as_mut()
+                    .poll_write(cx, &pkt.data[*written_val..]))?;
+                if n == 0 {
+                    *pkt_container = None;
+                    *written = None;
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write entire vmess udp packet: stream closed",
+                    )));
+                }
+                *written_val += n;
+                debug!(
+                    "send udp packet to remote vmess server, len: {}, written: {}, \
+                     total: {}, remote_addr: {}, dst_addr: {}",
+                    n,
+                    *written_val,
+                    pkt.data.len(),
+                    remote_addr,
+                    pkt.dst_addr
+                );
+            }
+
             if !*flushed {
                 let r = inner.as_mut().poll_flush(cx)?;
                 if r.is_pending() {
@@ -110,20 +134,10 @@ impl Sink<UdpPacket> for OutboundDatagramVmess {
                 }
                 *flushed = true;
             }
-            let total_len = pkt.data.len();
 
             *pkt_container = None;
-
-            let res = if written.unwrap() == total_len {
-                Ok(())
-            } else {
-                Err(new_io_error(format!(
-                    "failed to write entire datagram, written: {}",
-                    written.unwrap()
-                )))
-            };
             *written = None;
-            Poll::Ready(res)
+            Poll::Ready(Ok(()))
         } else {
             debug!("no udp packet to send");
             Poll::Ready(Err(io::Error::other("no packet to send")))


### PR DESCRIPTION
### Summary
- VLESS: Accumulates complete UDP packets across TCP chunk boundaries and length headers.
- VMess: Loops on partial `poll_write` until whole datagram is transmitted.
- Trojan: Guards against `poll_write` returning 0 to prevent infinite busy loops.
- gRPC: Falls through to register waker when payload is not yet buffered, preventing task hangs.
- ShadowTLS: Transitions to `WaitingHeader` on non-application records to prevent stream corruption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gRPC stream handling to prevent stalls when payload data arrives separately from headers.
  * Fixed ShadowTLS stream recovery when non-application records are received.
  * Prevented Trojan UDP sends from hanging when no bytes are written.
  * Added support for fragmented VLESS UDP packets across multiple reads.
  * Improved VMess UDP delivery by handling partial writes until the full payload is sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->