### PR TITLE
fix(memory): closed_flows memory leak and statistics deadlock

### DIFF
--- a/clash-lib/src/app/api/handlers/flows.rs
+++ b/clash-lib/src/app/api/handlers/flows.rs
@@ -219,12 +219,42 @@ async fn build_flow_records(
         merge_info!(info, chains, true);
     }
 
-    // Closed connections (ring buffer).
+    // Closed connections (ring buffer) — uses ClosedFlowInfo which has
+    // pre-extracted concrete fields (no session_holder/proxy_chain_holder needed).
     if include_closed {
         let closed = mgr.closed_flows_snapshot().await;
         for info in &closed {
-            let chains = info.proxy_chain_holder.snapshot().await;
-            merge_info!(info, chains, false);
+            let key = FlowKey {
+                dst_host: info.host.clone(),
+                dst_port: info.destination_port,
+                protocol: info.network.clone(),
+            };
+            let acc = map.entry(key).or_insert_with(|| Acc {
+                src_ips: Vec::new(),
+                conn_count: 0,
+                active_count: 0,
+                closed_count: 0,
+                upload_total: 0,
+                download_total: 0,
+                rule: String::new(),
+                rule_payload: String::new(),
+                chains: Vec::new(),
+                country: None,
+                asn: None,
+                last_seen: DateTime::<Utc>::MIN_UTC,
+            });
+            acc.apply(ConnEntry {
+                src_ip: info.source_ip.clone(),
+                upload: info.upload_total,
+                download: info.download_total,
+                rule: info.rule.clone(),
+                rule_payload: info.rule_payload.clone(),
+                chains: info.proxy_chain.clone(),
+                country: info.country.clone(),
+                asn: info.asn.clone(),
+                start_time: info.start_time,
+                is_active: false,
+            });
         }
     }
 

--- a/clash-lib/src/app/api/handlers/flows.rs
+++ b/clash-lib/src/app/api/handlers/flows.rs
@@ -220,7 +220,8 @@ async fn build_flow_records(
     }
 
     // Closed connections (ring buffer) — uses ClosedFlowInfo which has
-    // pre-extracted concrete fields (no session_holder/proxy_chain_holder needed).
+    // pre-extracted concrete fields (no session_holder/proxy_chain_holder
+    // needed).
     if include_closed {
         let closed = mgr.closed_flows_snapshot().await;
         for info in &closed {

--- a/clash-lib/src/app/dispatcher/mod.rs
+++ b/clash-lib/src/app/dispatcher/mod.rs
@@ -3,7 +3,7 @@ mod statistics_manager;
 mod tracked;
 
 pub use dispatcher_impl::Dispatcher;
-pub use statistics_manager::Manager as StatisticsManager;
+pub use statistics_manager::{Manager as StatisticsManager, MemLimitMode, set_closed_flows_cap};
 pub use tracked::{
     BoxedInstrumentedDatagram, BoxedInstrumentedStream, InstrumentedDatagram,
     InstrumentedDatagramWrapper, InstrumentedStream, InstrumentedStreamWrapper,

--- a/clash-lib/src/app/dispatcher/mod.rs
+++ b/clash-lib/src/app/dispatcher/mod.rs
@@ -3,7 +3,9 @@ mod statistics_manager;
 mod tracked;
 
 pub use dispatcher_impl::Dispatcher;
-pub use statistics_manager::{Manager as StatisticsManager, MemLimitMode, set_closed_flows_cap};
+pub use statistics_manager::{
+    ClosedFlowInfo, Manager as StatisticsManager, set_closed_flows_cap,
+};
 pub use tracked::{
     BoxedInstrumentedDatagram, BoxedInstrumentedStream, InstrumentedDatagram,
     InstrumentedDatagramWrapper, InstrumentedStream, InstrumentedStreamWrapper,

--- a/clash-lib/src/app/dispatcher/statistics_manager.rs
+++ b/clash-lib/src/app/dispatcher/statistics_manager.rs
@@ -8,10 +8,30 @@ use memory_stats::memory_stats;
 use portable_atomic::AtomicU64;
 use serde::Serialize;
 use tokio::sync::{Mutex, RwLock, oneshot::Sender};
+use tracing::warn;
 
-use crate::session::Session;
+use crate::{app::dns::ThreadSafeDNSResolver, app::remote_content_manager::set_global_traffic_rate, session::Session};
 
 use super::tracked::Tracked;
+
+/// Memory limit mode for the manager.
+/// When memory exceeds the limit, connections are closed to reduce memory
+/// usage instead of crashing the process.
+#[derive(Clone, Copy, Debug)]
+pub enum MemLimitMode {
+    /// No memory limit.
+    None,
+    /// Soft limit: close oldest connections when exceeded.
+    Soft,
+    /// Hard limit: close all connections when exceeded.
+    Hard,
+}
+
+impl Default for MemLimitMode {
+    fn default() -> Self {
+        Self::None
+    }
+}
 
 /// Per-user traffic since the last drain.  Both upload and download are in
 /// bytes.
@@ -107,9 +127,73 @@ pub struct Snapshot {
 
 type ConnectionMap = HashMap<uuid::Uuid, (Tracked, Sender<()>)>;
 
+/// Lightweight record stored in the `closed_flows` ring buffer.
+/// Unlike `TrackerInfo`, this does NOT hold `session_holder` (Session) or
+/// `proxy_chain_holder` (ProxyChain), which are the biggest memory consumers
+/// per connection. This prevents the ring buffer from retaining large objects
+/// after connections close, which was the root cause of "memory keeps growing
+/// after speed test stops".
+///
+/// Fields are stored as concrete types (not trait objects) so callers can
+/// access them directly without downcasting.
+#[derive(Serialize, Clone)]
+pub struct ClosedFlowInfo {
+    #[serde(rename = "id")]
+    pub uuid: uuid::Uuid,
+    #[serde(rename = "upload")]
+    pub upload_total: u64,
+    #[serde(rename = "download")]
+    pub download_total: u64,
+    #[serde(rename = "start")]
+    pub start_time: chrono::DateTime<Utc>,
+    #[serde(rename = "chains")]
+    pub proxy_chain: Vec<String>,
+    #[serde(rename = "rule")]
+    pub rule: String,
+    #[serde(rename = "rulePayload")]
+    pub rule_payload: String,
+    /// Pre-extracted from Session for /flows API consumption.
+    pub host: String,
+    pub destination_port: u16,
+    pub network: String,
+    pub source_ip: String,
+    pub country: Option<String>,
+    pub asn: Option<String>,
+}
+
+impl ClosedFlowInfo {
+    /// Create from a `TrackerInfo` by snapshotting atomic counters and
+    /// extracting concrete fields from session_holder. The heavy
+    /// `session_holder` and `proxy_chain_holder` are NOT carried over.
+    pub async fn from_tracker_info(info: &TrackerInfo) -> Self {
+        let chain = info.proxy_chain_holder.snapshot().await;
+        Self {
+            uuid: info.uuid,
+            upload_total: info.upload_total.load(Ordering::Acquire),
+            download_total: info.download_total.load(Ordering::Acquire),
+            start_time: info.start_time,
+            proxy_chain: chain,
+            rule: info.rule.clone(),
+            rule_payload: info.rule_payload.clone(),
+            host: info.session_holder.destination.host(),
+            destination_port: info.session_holder.destination.port(),
+            network: match info.session_holder.network {
+                crate::session::Network::Tcp => "tcp".to_string(),
+                crate::session::Network::Udp => "udp".to_string(),
+            },
+            source_ip: info.session_holder.source.ip().to_string(),
+            country: info.session_holder.country.clone(),
+            asn: info.session_holder.asn.clone(),
+        }
+    }
+}
+
 pub struct Manager {
     connections: Arc<Mutex<ConnectionMap>>,
-    closed_flows: Arc<Mutex<VecDeque<Arc<TrackerInfo>>>>,
+    /// Ring buffer of recently closed connections for the /flows API.
+    /// Uses `ClosedFlowInfo` (lightweight) instead of `Arc<TrackerInfo>`
+    /// to avoid retaining `Session` and `ProxyChain` after close.
+    closed_flows: Arc<Mutex<VecDeque<ClosedFlowInfo>>>,
     upload_temp: AtomicU64,
     download_temp: AtomicU64,
     upload_blip: AtomicU64,
@@ -119,10 +203,101 @@ pub struct Manager {
     /// Bytes accumulated from **closed** connections, keyed by inbound_user.
     /// Drained (and reset) by [`Manager::drain_user_stats`].
     user_period_stats: Arc<Mutex<HashMap<String, UserTraffic>>>,
+    /// Memory limit in bytes. 0 = unlimited.
+    mem_limit_bytes: AtomicU64,
+    /// Current memory limit mode.
+    mem_limit_mode: Mutex<MemLimitMode>,
+    /// Number of connections closed due to memory pressure (for stats).
+    mem_pressure_closes: AtomicU64,
+    /// Number of new connections rejected due to memory pressure (for stats).
+    mem_pressure_rejects: AtomicU64,
+    /// DNS resolver for clearing DNS caches under memory pressure.
+    /// Injected after construction via [`Manager::set_dns_resolver`].
+    dns_resolver: RwLock<Option<ThreadSafeDNSResolver>>,
+    /// Hard-mode trigger ratio (e.g. 2.0 = trigger at 2x limit).
+    /// Stored as the multiplier * 100 (200 = 2.0x) to fit in AtomicU64.
+    /// 0 = Hard mode disabled (user prefers OOM kill over connection drop).
+    mem_hard_ratio_x100: AtomicU64,
 }
+
+/// Default capacity of the `closed_flows` ring buffer.
+/// Can be overridden via `experimental.closed-flows-cap` in config.
+const DEFAULT_CLOSED_FLOWS_CAP: usize = 50;
+
+/// Global closed_flows capacity. Uses AtomicUsize so it can be
+/// updated on config reload (unlike OnceLock which is set-once).
+static CLOSED_FLOWS_CAP_CONFIG: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(DEFAULT_CLOSED_FLOWS_CAP);
+
+/// Set the global closed_flows capacity. Called during config loading.
+pub fn set_closed_flows_cap(cap: usize) {
+    CLOSED_FLOWS_CAP_CONFIG.store(cap, std::sync::atomic::Ordering::Release);
+}
+
+fn closed_flows_cap() -> usize {
+    CLOSED_FLOWS_CAP_CONFIG.load(std::sync::atomic::Ordering::Acquire)
+}
+
+/// Default hard-mode trigger: 2x the soft limit.
+const DEFAULT_HARD_RATIO_X100: u64 = 200;
+/// When Hard mode fires, close this fraction of connections (20%).
+const HARD_CLOSE_FRACTION_NUM: u64 = 20;
+const HARD_CLOSE_FRACTION_DEN: u64 = 100;
 
 impl Manager {
     pub fn new() -> Arc<Self> {
+        // Read memory limit from environment variable.
+        // Format: CLASH_RS_MEM_LIMIT_MB=40  (soft limit, close oldest conns)
+        //         CLASH_RS_MEM_LIMIT_MB=40:hard  (close all conns when exceeded)
+        let (limit_bytes, mode) = match std::env::var("CLASH_RS_MEM_LIMIT_MB") {
+            Ok(val) => {
+                let val = val.trim();
+                let (num_str, mode) = if let Some(rest) = val.strip_suffix(":hard")
+                {
+                    (rest, MemLimitMode::Hard)
+                } else if let Some(rest) = val.strip_suffix(":soft") {
+                    (rest, MemLimitMode::Soft)
+                } else {
+                    (val, MemLimitMode::Soft)
+                };
+                match num_str.parse::<u64>() {
+                    // Fix(2026-08-04): saturating to avoid u64 overflow on
+                    // absurd values (mb * 1024 * 1024 overflows at mb >= 2^44).
+                    Ok(mb) if mb > 0 => {
+                        (mb.saturating_mul(1024).saturating_mul(1024), mode)
+                    }
+                    _ => (0, MemLimitMode::None),
+                }
+            }
+            Err(_) => (0, MemLimitMode::None),
+        };
+
+        // Read optional hard-mode trigger ratio.
+        // Format: CLASH_RS_MEM_HARD_RATIO=1.5  (trigger Hard at 1.5x limit)
+        //         CLASH_RS_MEM_HARD_RATIO=0    (disable Hard mode entirely)
+        // Default: 2.0 (Hard triggers at 2x limit)
+        let hard_ratio_x100 = match std::env::var("CLASH_RS_MEM_HARD_RATIO") {
+            Ok(val) => {
+                let val = val.trim();
+                match val.parse::<f64>() {
+                    Ok(r) if r < 0.0 => DEFAULT_HARD_RATIO_X100,
+                    Ok(r) if r == 0.0 => 0, // user explicitly disables Hard
+                    // ratio < 1.0 is nonsensical: Hard mode (close existing
+                    // conns) would trigger BEFORE Soft mode (reject new conns
+                    // at 1x limit).  Clamp to default to avoid logic inversion.
+                    Ok(r) if r < 1.0 => DEFAULT_HARD_RATIO_X100,
+                    // Fix(2026-08-04): guard NaN/Inf (parse::<f64>("NaN") is
+                    // Ok(NaN); (NaN*100) as u64 == 0 silently disabled Hard).
+                    Ok(r) if r.is_finite() && r >= 1.0 => {
+                        (r * 100.0).round() as u64
+                    }
+                    Ok(_) => DEFAULT_HARD_RATIO_X100,
+                    Err(_) => DEFAULT_HARD_RATIO_X100,
+                }
+            }
+            Err(_) => DEFAULT_HARD_RATIO_X100,
+        };
+
         let v = Arc::new(Self {
             connections: Arc::new(Mutex::new(HashMap::new())),
             closed_flows: Arc::new(Mutex::new(VecDeque::new())),
@@ -133,6 +308,12 @@ impl Manager {
             upload_total: AtomicU64::new(0),
             download_total: AtomicU64::new(0),
             user_period_stats: Arc::new(Mutex::new(HashMap::new())),
+            mem_limit_bytes: AtomicU64::new(limit_bytes),
+            mem_limit_mode: Mutex::new(mode),
+            mem_pressure_closes: AtomicU64::new(0),
+            mem_pressure_rejects: AtomicU64::new(0),
+            dns_resolver: RwLock::new(None),
+            mem_hard_ratio_x100: AtomicU64::new(hard_ratio_x100),
         });
         let c = v.clone();
         tokio::spawn(async move {
@@ -141,9 +322,54 @@ impl Manager {
         v
     }
 
-    pub async fn track(&self, item: Tracked, close_notify: Sender<()>) {
-        let mut connections = self.connections.lock().await;
+    /// Set memory limit at runtime (bytes). 0 = unlimited.
+    pub async fn set_memory_limit(&self, bytes: u64, mode: MemLimitMode) {
+        self.mem_limit_bytes.store(bytes, Ordering::Relaxed);
+        let mut m = self.mem_limit_mode.lock().await;
+        *m = mode;
+    }
 
+    /// Returns the configured memory limit in bytes (0 = unlimited).
+    pub fn memory_limit(&self) -> u64 {
+        self.mem_limit_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Returns the count of connections closed due to memory pressure.
+    pub fn memory_pressure_closes(&self) -> u64 {
+        self.mem_pressure_closes.load(Ordering::Relaxed)
+    }
+
+    /// Inject the DNS resolver so caches can be cleared under memory pressure.
+    /// Called once during startup after both the resolver and manager exist.
+    pub async fn set_dns_resolver(&self, r: ThreadSafeDNSResolver) {
+        let mut guard = self.dns_resolver.write().await;
+        *guard = Some(r);
+    }
+
+    pub async fn track(&self, item: Tracked, close_notify: Sender<()>) {
+        // Memory pressure check: reject NEW connections when over limit.
+        // Existing connections are kept alive (network stays up, just slower).
+        // When memory drops below limit, new connections are accepted again.
+        let limit = self.mem_limit_bytes.load(Ordering::Relaxed);
+        if limit > 0 {
+            let current = self.memory_usage();
+            // Fix(2026-08-04): `limit as usize` truncates to 0 on 32-bit
+            // targets when limit >= 4GiB, disabling the guard entirely.
+            if (current as u64) > limit {
+                // Memory over limit - reject this new connection.
+                // close_notify signals the connection to close immediately.
+                let _ = close_notify.send(());
+                self.mem_pressure_rejects
+                    .fetch_add(1, Ordering::Relaxed);
+                warn!(
+                    "memory pressure: {} bytes > {} limit, rejected new connection (existing conns kept alive)",
+                    current, limit
+                );
+                return;
+            }
+        }
+
+        let mut connections = self.connections.lock().await;
         connections.insert(item.id(), (item, close_notify));
     }
 
@@ -157,11 +383,18 @@ impl Manager {
         let closed_flows = self.closed_flows.clone();
 
         tokio::spawn(async move {
-            let mut connections = connections.lock().await;
-            if let Some((tracked, _)) = connections.remove(&id) {
-                let info = tracked.tracker_info();
-                // Atomically take the remaining user-accounting bytes.
-                // upload_total/download_total are left intact for /connections.
+            // Phase 1: hold connections lock only to remove the entry.
+            // We must NOT acquire user_period_stats or closed_flows while
+            // holding connections, because drain_user_stats acquires
+            // user_period_stats -> connections (reverse order = AB-BA deadlock).
+            let info = {
+                let mut connections = connections.lock().await;
+                connections.remove(&id).map(|(tracked, _)| tracked.tracker_info())
+            };
+            // --- connections lock released ---
+
+            if let Some(info) = info {
+                // Phase 2: update user stats (no connections lock held).
                 let upload = info.user_upload.swap(0, Ordering::AcqRel);
                 let download = info.user_download.swap(0, Ordering::AcqRel);
                 if let Some(ref user) = info.session_holder.inbound_user
@@ -175,10 +408,18 @@ impl Manager {
                     entry.download += download;
                 }
 
-                // Push to the closed_flows ring buffer (cap 1000).
+                // Phase 3: push lightweight ClosedFlowInfo to closed_flows.
+                // This avoids retaining session_holder and proxy_chain_holder
+                // in the ring buffer, which was the root cause of memory
+                // growing after speed test stops.
+                let flow = ClosedFlowInfo::from_tracker_info(&info).await;
+                // info (Arc<TrackerInfo>) is dropped here — no more references
+                // to the heavy Session/ProxyChain from the ring buffer.
+                drop(info);
                 let mut ring = closed_flows.lock().await;
-                ring.push_back(info);
-                if ring.len() > 1000 {
+                let cap = closed_flows_cap();
+                ring.push_back(flow);
+                while ring.len() > cap {
                     ring.pop_front();
                 }
             }
@@ -196,8 +437,8 @@ impl Manager {
             .collect()
     }
 
-    /// Return a snapshot of recently closed connections (up to 1000 entries).
-    pub async fn closed_flows_snapshot(&self) -> Vec<Arc<TrackerInfo>> {
+    /// Return a snapshot of recently closed connections.
+    pub async fn closed_flows_snapshot(&self) -> Vec<ClosedFlowInfo> {
         let ring = self.closed_flows.lock().await;
         ring.iter().cloned().collect()
     }
@@ -237,8 +478,14 @@ impl Manager {
         let connections = self.connections.clone();
 
         tokio::spawn(async move {
-            let mut connections = connections.lock().await;
-            if let Some((_, close_notify)) = connections.remove(&id) {
+            // Phase 1: remove under lock, collect close_notify.
+            let close_notify = {
+                let mut connections = connections.lock().await;
+                connections.remove(&id).map(|(_, cn)| cn)
+            };
+            // --- lock released ---
+            // Phase 2: signal outside the lock.
+            if let Some(close_notify) = close_notify {
                 let _ = close_notify.send(());
             }
         });
@@ -247,8 +494,14 @@ impl Manager {
     pub async fn close_all(&self) {
         let connections = self.connections.clone();
 
-        let mut connections = connections.lock().await;
-        for (_, (_, close_notify)) in connections.drain() {
+        // Phase 1: drain all entries under lock, collect close_notifiers.
+        let pending: Vec<Sender<()>> = {
+            let mut connections = connections.lock().await;
+            connections.drain().map(|(_, (_, cn))| cn).collect()
+        };
+        // --- lock released ---
+        // Phase 2: signal all outside the lock.
+        for close_notify in pending {
             let _ = close_notify.send(());
         }
     }
@@ -338,7 +591,10 @@ impl Manager {
     }
 
     async fn kick_off(&self) {
+        // Memory check runs every 5 seconds (not every 1s) to reduce CPU load.
+        // Traffic blip still updates every 1s.
         let mut ticker = tokio::time::interval(std::time::Duration::from_secs(1));
+        let mut mem_check_counter: u32 = 0;
         loop {
             ticker.tick().await;
             self.upload_blip
@@ -349,6 +605,191 @@ impl Manager {
                 Ordering::Relaxed,
             );
             self.download_temp.store(0, Ordering::Relaxed);
+
+            // 更新全局流量速率供 url-test group 使用
+            set_global_traffic_rate(
+                self.upload_blip.load(Ordering::Relaxed),
+                self.download_blip.load(Ordering::Relaxed),
+            );
+
+            // Memory pressure check every 5 seconds
+            mem_check_counter += 1;
+            if mem_check_counter >= 5 {
+                mem_check_counter = 0;
+                self.check_memory_pressure().await;
+            }
+        }
+    }
+
+    /// Check memory usage and take action if over the limit.
+    ///
+    /// Strategy (network stays up, just slower):
+    /// - New connections are rejected in `track()` when over limit (soft & hard)
+    /// - Soft mode: only reject new connections, keep all existing alive
+    /// - Hard mode: also close existing connections when severely over limit (2x)
+    ///   to prevent OOM crash. This is last-resort, only triggers at 2x limit.
+    ///
+    /// When memory drops below limit, all restrictions auto-clear.
+    ///
+    /// **Business-layer cache cleanup** (both modes, when over 1x limit):
+    /// - Clear `closed_flows` ring buffer (frees TrackerInfo with Session strings)
+    /// - Clear DNS reverse_lookup_cache via injected resolver
+    /// This releases references so jemalloc can reclaim pages (with short decay_ms
+    /// configured in main.rs, pages return to OS within ~1 second).
+    async fn check_memory_pressure(&self) {
+        let limit = self.mem_limit_bytes.load(Ordering::Relaxed);
+        if limit == 0 {
+            return;
+        }
+
+        let current = self.memory_usage();
+        // Fix(2026-08-04): keep u64 on 32-bit targets (`as usize` truncates
+        // limits >= 4GiB to 0).
+        let limit_u64 = limit;
+
+        // --- Business-layer cache cleanup (both modes, when over 1x limit) ---
+        // Free references so jemalloc can reclaim pages.  This is the primary
+        // mechanism for RSS reduction: without freeing the objects, no amount
+        // of allocator tuning will help.
+        if (current as u64) > limit_u64 {
+            // 1. Clear closed_flows ring buffer (biggest business-layer cache)
+            {
+                let mut ring = self.closed_flows.lock().await;
+                let freed = ring.len();
+                if freed > 0 {
+                    ring.clear();
+                    warn!(
+                        "memory pressure: cleared {} closed_flows entries ({} bytes > {} limit)",
+                        freed, current, limit_u64
+                    );
+                }
+            }
+
+            // 2. Clear DNS caches (reverse_lookup_cache)
+            // Fix(2026-08-04): clone resolver ref before .await to avoid
+            // holding the read lock across the async boundary, which can
+            // deadlock set_dns_resolver().
+            {
+                let guard = self.dns_resolver.read().await;
+                let resolver_opt = guard.clone();
+                drop(guard);
+                if let Some(r) = resolver_opt.as_ref() {
+                    r.clear_cache().await;
+                }
+            }
+
+            // Note: jemalloc epoch advance is not needed here.  With short
+            // decay_ms (1s, set in main.rs via tune_jemalloc), freed pages are
+            // automatically returned to OS by jemalloc's background decay.
+            // epoch::advance() only refreshes stats, doesn't trigger purge.
+        }
+
+        // --- Existing-connection closure (Hard mode only, at configurable ratio) ---
+        let mode = *self.mem_limit_mode.lock().await;
+        let ratio_x100 = self.mem_hard_ratio_x100.load(Ordering::Relaxed);
+        match mode {
+            MemLimitMode::None | MemLimitMode::Soft => {
+                // Soft mode: never close existing connections.
+                // New connections are already rejected in track().
+            }
+            MemLimitMode::Hard if ratio_x100 == 0 => {
+                // User explicitly disabled Hard mode (CLASH_RS_MEM_HARD_RATIO=0).
+                // They prefer OOM kill over forced connection drop.
+            }
+            MemLimitMode::Hard => {
+                // Hard mode: close some existing connections when memory exceeds
+                // the configured ratio (default 2x) of the limit.
+                //
+                // Re-read memory AFTER cache cleanup above: clearing
+                // closed_flows / DNS caches frees references, and while
+                // jemalloc decay takes time, the dropped allocations themselves
+                // are immediate.  Using the stale pre-cleanup value would risk
+                // closing connections that are no longer necessary.
+                let current = self.memory_usage();
+                // Fix(2026-08-04): clamp u128 -> usize (32-bit safety).
+                let threshold = ((limit_u64 as u128 * ratio_x100 as u128 / 100)
+                    .min(usize::MAX as u128)) as usize;
+                if current <= threshold {
+                    return;
+                }
+
+                // --- Phase 1: hold the lock only to collect candidates ---
+                // We must NOT call close_notify.send() while holding the
+                // connections lock: send() can block (if the receiver is slow
+                // or dropped), which would stall the entire routing table and
+                // freeze all new connections.  Read-decide-remove under the
+                // lock, then drop the lock before signaling.
+                let (count, to_close, mut pending_close) = {
+                    let mut connections = self.connections.lock().await;
+                    let count = connections.len() as u64;
+                    if count == 0 {
+                        return;
+                    }
+
+                    // Smart eviction: prioritize closing connections that are
+                    // (a) UDP (cheaper to reconnect — P2P/QUIC retransmit)
+                    // (b) idle (lowest total bytes transferred)
+                    // This avoids killing active TCP streams (SSH, video, downloads).
+                    let mut candidates: Vec<(uuid::Uuid, u64, bool)> = connections
+                        .iter()
+                        .map(|(id, (tracked, _))| {
+                            let info = tracked.tracker_info();
+                            let bytes = info.upload_total.load(Ordering::Relaxed)
+                                + info.download_total.load(Ordering::Relaxed);
+                            let is_udp = info.session_holder.network
+                                == crate::session::Network::Udp;
+                            (*id, bytes, is_udp)
+                        })
+                        .collect();
+                    // Sort: UDP first (evict before TCP), then by ascending bytes
+                    // (idle before active).  Stable sort keeps insertion order
+                    // for ties (older connections evicted first).
+                    candidates.sort_by(|a, b| {
+                        // UDP (true) sorts before TCP (false)
+                        b.2.cmp(&a.2).then_with(|| a.1.cmp(&b.1))
+                    });
+
+                    // Close only the bottom 20% (not 50%) to keep network
+                    // partially up — gives the system room to recover.
+                    // .max(1) guarantees we always evict at least one
+                    // connection when triggered (avoids the integer-division
+                    // trap where 2 * 20 / 100 == 0).
+                    let to_close = (count * HARD_CLOSE_FRACTION_NUM
+                        / HARD_CLOSE_FRACTION_DEN)
+                        .max(1) as usize;
+
+                    // Remove the chosen IDs from the map and collect their
+                    // close notifiers.  The lock is released at the end of
+                    // this block.
+                    let mut pending: Vec<Sender<()>> = Vec::with_capacity(to_close);
+                    for (id, _, _) in candidates.into_iter().take(to_close) {
+                        if let Some((_, close_notify)) = connections.remove(&id) {
+                            pending.push(close_notify);
+                        }
+                    }
+                    (count, to_close, pending)
+                };
+                // --- Lock released ---
+
+                // --- Phase 2: signal closure outside the lock ---
+                // close_notify.send(()) is a oneshot send — usually instant,
+                // but if the receiver task is busy or the runtime is
+                // congested, we don't want to block the routing table.
+                let mut closed = 0u64;
+                for close_notify in pending_close.drain(..) {
+                    let _ = close_notify.send(());
+                    closed += 1;
+                }
+
+                if closed > 0 {
+                    self.mem_pressure_closes
+                        .fetch_add(closed, Ordering::Relaxed);
+                    warn!(
+                        "memory pressure SEVERE: {} bytes > {}x{} limit, smart-evicted {}/{} connections (target {}, UDP+idle first, hard mode)",
+                        current, ratio_x100, limit_u64, closed, count, to_close
+                    );
+                }
+            }
         }
     }
 }

--- a/clash-lib/src/app/dispatcher/statistics_manager.rs
+++ b/clash-lib/src/app/dispatcher/statistics_manager.rs
@@ -8,30 +8,10 @@ use memory_stats::memory_stats;
 use portable_atomic::AtomicU64;
 use serde::Serialize;
 use tokio::sync::{Mutex, RwLock, oneshot::Sender};
-use tracing::warn;
 
-use crate::{app::dns::ThreadSafeDNSResolver, app::remote_content_manager::set_global_traffic_rate, session::Session};
+use crate::session::Session;
 
 use super::tracked::Tracked;
-
-/// Memory limit mode for the manager.
-/// When memory exceeds the limit, connections are closed to reduce memory
-/// usage instead of crashing the process.
-#[derive(Clone, Copy, Debug)]
-pub enum MemLimitMode {
-    /// No memory limit.
-    None,
-    /// Soft limit: close oldest connections when exceeded.
-    Soft,
-    /// Hard limit: close all connections when exceeded.
-    Hard,
-}
-
-impl Default for MemLimitMode {
-    fn default() -> Self {
-        Self::None
-    }
-}
 
 /// Per-user traffic since the last drain.  Both upload and download are in
 /// bytes.
@@ -203,21 +183,6 @@ pub struct Manager {
     /// Bytes accumulated from **closed** connections, keyed by inbound_user.
     /// Drained (and reset) by [`Manager::drain_user_stats`].
     user_period_stats: Arc<Mutex<HashMap<String, UserTraffic>>>,
-    /// Memory limit in bytes. 0 = unlimited.
-    mem_limit_bytes: AtomicU64,
-    /// Current memory limit mode.
-    mem_limit_mode: Mutex<MemLimitMode>,
-    /// Number of connections closed due to memory pressure (for stats).
-    mem_pressure_closes: AtomicU64,
-    /// Number of new connections rejected due to memory pressure (for stats).
-    mem_pressure_rejects: AtomicU64,
-    /// DNS resolver for clearing DNS caches under memory pressure.
-    /// Injected after construction via [`Manager::set_dns_resolver`].
-    dns_resolver: RwLock<Option<ThreadSafeDNSResolver>>,
-    /// Hard-mode trigger ratio (e.g. 2.0 = trigger at 2x limit).
-    /// Stored as the multiplier * 100 (200 = 2.0x) to fit in AtomicU64.
-    /// 0 = Hard mode disabled (user prefers OOM kill over connection drop).
-    mem_hard_ratio_x100: AtomicU64,
 }
 
 /// Default capacity of the `closed_flows` ring buffer.
@@ -238,66 +203,8 @@ fn closed_flows_cap() -> usize {
     CLOSED_FLOWS_CAP_CONFIG.load(std::sync::atomic::Ordering::Acquire)
 }
 
-/// Default hard-mode trigger: 2x the soft limit.
-const DEFAULT_HARD_RATIO_X100: u64 = 200;
-/// When Hard mode fires, close this fraction of connections (20%).
-const HARD_CLOSE_FRACTION_NUM: u64 = 20;
-const HARD_CLOSE_FRACTION_DEN: u64 = 100;
-
 impl Manager {
     pub fn new() -> Arc<Self> {
-        // Read memory limit from environment variable.
-        // Format: CLASH_RS_MEM_LIMIT_MB=40  (soft limit, close oldest conns)
-        //         CLASH_RS_MEM_LIMIT_MB=40:hard  (close all conns when exceeded)
-        let (limit_bytes, mode) = match std::env::var("CLASH_RS_MEM_LIMIT_MB") {
-            Ok(val) => {
-                let val = val.trim();
-                let (num_str, mode) = if let Some(rest) = val.strip_suffix(":hard")
-                {
-                    (rest, MemLimitMode::Hard)
-                } else if let Some(rest) = val.strip_suffix(":soft") {
-                    (rest, MemLimitMode::Soft)
-                } else {
-                    (val, MemLimitMode::Soft)
-                };
-                match num_str.parse::<u64>() {
-                    // Fix(2026-08-04): saturating to avoid u64 overflow on
-                    // absurd values (mb * 1024 * 1024 overflows at mb >= 2^44).
-                    Ok(mb) if mb > 0 => {
-                        (mb.saturating_mul(1024).saturating_mul(1024), mode)
-                    }
-                    _ => (0, MemLimitMode::None),
-                }
-            }
-            Err(_) => (0, MemLimitMode::None),
-        };
-
-        // Read optional hard-mode trigger ratio.
-        // Format: CLASH_RS_MEM_HARD_RATIO=1.5  (trigger Hard at 1.5x limit)
-        //         CLASH_RS_MEM_HARD_RATIO=0    (disable Hard mode entirely)
-        // Default: 2.0 (Hard triggers at 2x limit)
-        let hard_ratio_x100 = match std::env::var("CLASH_RS_MEM_HARD_RATIO") {
-            Ok(val) => {
-                let val = val.trim();
-                match val.parse::<f64>() {
-                    Ok(r) if r < 0.0 => DEFAULT_HARD_RATIO_X100,
-                    Ok(r) if r == 0.0 => 0, // user explicitly disables Hard
-                    // ratio < 1.0 is nonsensical: Hard mode (close existing
-                    // conns) would trigger BEFORE Soft mode (reject new conns
-                    // at 1x limit).  Clamp to default to avoid logic inversion.
-                    Ok(r) if r < 1.0 => DEFAULT_HARD_RATIO_X100,
-                    // Fix(2026-08-04): guard NaN/Inf (parse::<f64>("NaN") is
-                    // Ok(NaN); (NaN*100) as u64 == 0 silently disabled Hard).
-                    Ok(r) if r.is_finite() && r >= 1.0 => {
-                        (r * 100.0).round() as u64
-                    }
-                    Ok(_) => DEFAULT_HARD_RATIO_X100,
-                    Err(_) => DEFAULT_HARD_RATIO_X100,
-                }
-            }
-            Err(_) => DEFAULT_HARD_RATIO_X100,
-        };
-
         let v = Arc::new(Self {
             connections: Arc::new(Mutex::new(HashMap::new())),
             closed_flows: Arc::new(Mutex::new(VecDeque::new())),
@@ -308,12 +215,6 @@ impl Manager {
             upload_total: AtomicU64::new(0),
             download_total: AtomicU64::new(0),
             user_period_stats: Arc::new(Mutex::new(HashMap::new())),
-            mem_limit_bytes: AtomicU64::new(limit_bytes),
-            mem_limit_mode: Mutex::new(mode),
-            mem_pressure_closes: AtomicU64::new(0),
-            mem_pressure_rejects: AtomicU64::new(0),
-            dns_resolver: RwLock::new(None),
-            mem_hard_ratio_x100: AtomicU64::new(hard_ratio_x100),
         });
         let c = v.clone();
         tokio::spawn(async move {
@@ -322,53 +223,7 @@ impl Manager {
         v
     }
 
-    /// Set memory limit at runtime (bytes). 0 = unlimited.
-    pub async fn set_memory_limit(&self, bytes: u64, mode: MemLimitMode) {
-        self.mem_limit_bytes.store(bytes, Ordering::Relaxed);
-        let mut m = self.mem_limit_mode.lock().await;
-        *m = mode;
-    }
-
-    /// Returns the configured memory limit in bytes (0 = unlimited).
-    pub fn memory_limit(&self) -> u64 {
-        self.mem_limit_bytes.load(Ordering::Relaxed)
-    }
-
-    /// Returns the count of connections closed due to memory pressure.
-    pub fn memory_pressure_closes(&self) -> u64 {
-        self.mem_pressure_closes.load(Ordering::Relaxed)
-    }
-
-    /// Inject the DNS resolver so caches can be cleared under memory pressure.
-    /// Called once during startup after both the resolver and manager exist.
-    pub async fn set_dns_resolver(&self, r: ThreadSafeDNSResolver) {
-        let mut guard = self.dns_resolver.write().await;
-        *guard = Some(r);
-    }
-
     pub async fn track(&self, item: Tracked, close_notify: Sender<()>) {
-        // Memory pressure check: reject NEW connections when over limit.
-        // Existing connections are kept alive (network stays up, just slower).
-        // When memory drops below limit, new connections are accepted again.
-        let limit = self.mem_limit_bytes.load(Ordering::Relaxed);
-        if limit > 0 {
-            let current = self.memory_usage();
-            // Fix(2026-08-04): `limit as usize` truncates to 0 on 32-bit
-            // targets when limit >= 4GiB, disabling the guard entirely.
-            if (current as u64) > limit {
-                // Memory over limit - reject this new connection.
-                // close_notify signals the connection to close immediately.
-                let _ = close_notify.send(());
-                self.mem_pressure_rejects
-                    .fetch_add(1, Ordering::Relaxed);
-                warn!(
-                    "memory pressure: {} bytes > {} limit, rejected new connection (existing conns kept alive)",
-                    current, limit
-                );
-                return;
-            }
-        }
-
         let mut connections = self.connections.lock().await;
         connections.insert(item.id(), (item, close_notify));
     }
@@ -386,10 +241,13 @@ impl Manager {
             // Phase 1: hold connections lock only to remove the entry.
             // We must NOT acquire user_period_stats or closed_flows while
             // holding connections, because drain_user_stats acquires
-            // user_period_stats -> connections (reverse order = AB-BA deadlock).
+            // user_period_stats -> connections (reverse order = AB-BA
+            // deadlock).
             let info = {
                 let mut connections = connections.lock().await;
-                connections.remove(&id).map(|(tracked, _)| tracked.tracker_info())
+                connections
+                    .remove(&id)
+                    .map(|(tracked, _)| tracked.tracker_info())
             };
             // --- connections lock released ---
 
@@ -458,7 +316,7 @@ impl Manager {
         // their user counters to 0. upload_total/download_total are untouched
         // so /connections keeps seeing the correct cumulative values.
         let connections = self.connections.lock().await;
-        for (tracked, _) in connections.values() {
+        for (_, (tracked, _)) in connections.iter() {
             let info = tracked.tracker_info();
             if let Some(ref user) = info.session_holder.inbound_user {
                 let upload = info.user_upload.swap(0, Ordering::AcqRel);
@@ -478,14 +336,8 @@ impl Manager {
         let connections = self.connections.clone();
 
         tokio::spawn(async move {
-            // Phase 1: remove under lock, collect close_notify.
-            let close_notify = {
-                let mut connections = connections.lock().await;
-                connections.remove(&id).map(|(_, cn)| cn)
-            };
-            // --- lock released ---
-            // Phase 2: signal outside the lock.
-            if let Some(close_notify) = close_notify {
+            let mut connections = connections.lock().await;
+            if let Some((_, close_notify)) = connections.remove(&id) {
                 let _ = close_notify.send(());
             }
         });
@@ -494,14 +346,8 @@ impl Manager {
     pub async fn close_all(&self) {
         let connections = self.connections.clone();
 
-        // Phase 1: drain all entries under lock, collect close_notifiers.
-        let pending: Vec<Sender<()>> = {
-            let mut connections = connections.lock().await;
-            connections.drain().map(|(_, (_, cn))| cn).collect()
-        };
-        // --- lock released ---
-        // Phase 2: signal all outside the lock.
-        for close_notify in pending {
+        let mut connections = connections.lock().await;
+        for (_, (_, close_notify)) in connections.drain() {
             let _ = close_notify.send(());
         }
     }
@@ -531,7 +377,7 @@ impl Manager {
     pub async fn snapshot(&self) -> Snapshot {
         let mut connections = vec![];
         let conns = self.connections.lock().await;
-        for v in conns.values() {
+        for (_, v) in conns.iter() {
             let t = v.0.tracker_info();
             let chain = t.proxy_chain_holder.0.read().await;
             connections.push(TrackerInfo {
@@ -591,10 +437,7 @@ impl Manager {
     }
 
     async fn kick_off(&self) {
-        // Memory check runs every 5 seconds (not every 1s) to reduce CPU load.
-        // Traffic blip still updates every 1s.
         let mut ticker = tokio::time::interval(std::time::Duration::from_secs(1));
-        let mut mem_check_counter: u32 = 0;
         loop {
             ticker.tick().await;
             self.upload_blip
@@ -605,191 +448,6 @@ impl Manager {
                 Ordering::Relaxed,
             );
             self.download_temp.store(0, Ordering::Relaxed);
-
-            // 更新全局流量速率供 url-test group 使用
-            set_global_traffic_rate(
-                self.upload_blip.load(Ordering::Relaxed),
-                self.download_blip.load(Ordering::Relaxed),
-            );
-
-            // Memory pressure check every 5 seconds
-            mem_check_counter += 1;
-            if mem_check_counter >= 5 {
-                mem_check_counter = 0;
-                self.check_memory_pressure().await;
-            }
-        }
-    }
-
-    /// Check memory usage and take action if over the limit.
-    ///
-    /// Strategy (network stays up, just slower):
-    /// - New connections are rejected in `track()` when over limit (soft & hard)
-    /// - Soft mode: only reject new connections, keep all existing alive
-    /// - Hard mode: also close existing connections when severely over limit (2x)
-    ///   to prevent OOM crash. This is last-resort, only triggers at 2x limit.
-    ///
-    /// When memory drops below limit, all restrictions auto-clear.
-    ///
-    /// **Business-layer cache cleanup** (both modes, when over 1x limit):
-    /// - Clear `closed_flows` ring buffer (frees TrackerInfo with Session strings)
-    /// - Clear DNS reverse_lookup_cache via injected resolver
-    /// This releases references so jemalloc can reclaim pages (with short decay_ms
-    /// configured in main.rs, pages return to OS within ~1 second).
-    async fn check_memory_pressure(&self) {
-        let limit = self.mem_limit_bytes.load(Ordering::Relaxed);
-        if limit == 0 {
-            return;
-        }
-
-        let current = self.memory_usage();
-        // Fix(2026-08-04): keep u64 on 32-bit targets (`as usize` truncates
-        // limits >= 4GiB to 0).
-        let limit_u64 = limit;
-
-        // --- Business-layer cache cleanup (both modes, when over 1x limit) ---
-        // Free references so jemalloc can reclaim pages.  This is the primary
-        // mechanism for RSS reduction: without freeing the objects, no amount
-        // of allocator tuning will help.
-        if (current as u64) > limit_u64 {
-            // 1. Clear closed_flows ring buffer (biggest business-layer cache)
-            {
-                let mut ring = self.closed_flows.lock().await;
-                let freed = ring.len();
-                if freed > 0 {
-                    ring.clear();
-                    warn!(
-                        "memory pressure: cleared {} closed_flows entries ({} bytes > {} limit)",
-                        freed, current, limit_u64
-                    );
-                }
-            }
-
-            // 2. Clear DNS caches (reverse_lookup_cache)
-            // Fix(2026-08-04): clone resolver ref before .await to avoid
-            // holding the read lock across the async boundary, which can
-            // deadlock set_dns_resolver().
-            {
-                let guard = self.dns_resolver.read().await;
-                let resolver_opt = guard.clone();
-                drop(guard);
-                if let Some(r) = resolver_opt.as_ref() {
-                    r.clear_cache().await;
-                }
-            }
-
-            // Note: jemalloc epoch advance is not needed here.  With short
-            // decay_ms (1s, set in main.rs via tune_jemalloc), freed pages are
-            // automatically returned to OS by jemalloc's background decay.
-            // epoch::advance() only refreshes stats, doesn't trigger purge.
-        }
-
-        // --- Existing-connection closure (Hard mode only, at configurable ratio) ---
-        let mode = *self.mem_limit_mode.lock().await;
-        let ratio_x100 = self.mem_hard_ratio_x100.load(Ordering::Relaxed);
-        match mode {
-            MemLimitMode::None | MemLimitMode::Soft => {
-                // Soft mode: never close existing connections.
-                // New connections are already rejected in track().
-            }
-            MemLimitMode::Hard if ratio_x100 == 0 => {
-                // User explicitly disabled Hard mode (CLASH_RS_MEM_HARD_RATIO=0).
-                // They prefer OOM kill over forced connection drop.
-            }
-            MemLimitMode::Hard => {
-                // Hard mode: close some existing connections when memory exceeds
-                // the configured ratio (default 2x) of the limit.
-                //
-                // Re-read memory AFTER cache cleanup above: clearing
-                // closed_flows / DNS caches frees references, and while
-                // jemalloc decay takes time, the dropped allocations themselves
-                // are immediate.  Using the stale pre-cleanup value would risk
-                // closing connections that are no longer necessary.
-                let current = self.memory_usage();
-                // Fix(2026-08-04): clamp u128 -> usize (32-bit safety).
-                let threshold = ((limit_u64 as u128 * ratio_x100 as u128 / 100)
-                    .min(usize::MAX as u128)) as usize;
-                if current <= threshold {
-                    return;
-                }
-
-                // --- Phase 1: hold the lock only to collect candidates ---
-                // We must NOT call close_notify.send() while holding the
-                // connections lock: send() can block (if the receiver is slow
-                // or dropped), which would stall the entire routing table and
-                // freeze all new connections.  Read-decide-remove under the
-                // lock, then drop the lock before signaling.
-                let (count, to_close, mut pending_close) = {
-                    let mut connections = self.connections.lock().await;
-                    let count = connections.len() as u64;
-                    if count == 0 {
-                        return;
-                    }
-
-                    // Smart eviction: prioritize closing connections that are
-                    // (a) UDP (cheaper to reconnect — P2P/QUIC retransmit)
-                    // (b) idle (lowest total bytes transferred)
-                    // This avoids killing active TCP streams (SSH, video, downloads).
-                    let mut candidates: Vec<(uuid::Uuid, u64, bool)> = connections
-                        .iter()
-                        .map(|(id, (tracked, _))| {
-                            let info = tracked.tracker_info();
-                            let bytes = info.upload_total.load(Ordering::Relaxed)
-                                + info.download_total.load(Ordering::Relaxed);
-                            let is_udp = info.session_holder.network
-                                == crate::session::Network::Udp;
-                            (*id, bytes, is_udp)
-                        })
-                        .collect();
-                    // Sort: UDP first (evict before TCP), then by ascending bytes
-                    // (idle before active).  Stable sort keeps insertion order
-                    // for ties (older connections evicted first).
-                    candidates.sort_by(|a, b| {
-                        // UDP (true) sorts before TCP (false)
-                        b.2.cmp(&a.2).then_with(|| a.1.cmp(&b.1))
-                    });
-
-                    // Close only the bottom 20% (not 50%) to keep network
-                    // partially up — gives the system room to recover.
-                    // .max(1) guarantees we always evict at least one
-                    // connection when triggered (avoids the integer-division
-                    // trap where 2 * 20 / 100 == 0).
-                    let to_close = (count * HARD_CLOSE_FRACTION_NUM
-                        / HARD_CLOSE_FRACTION_DEN)
-                        .max(1) as usize;
-
-                    // Remove the chosen IDs from the map and collect their
-                    // close notifiers.  The lock is released at the end of
-                    // this block.
-                    let mut pending: Vec<Sender<()>> = Vec::with_capacity(to_close);
-                    for (id, _, _) in candidates.into_iter().take(to_close) {
-                        if let Some((_, close_notify)) = connections.remove(&id) {
-                            pending.push(close_notify);
-                        }
-                    }
-                    (count, to_close, pending)
-                };
-                // --- Lock released ---
-
-                // --- Phase 2: signal closure outside the lock ---
-                // close_notify.send(()) is a oneshot send — usually instant,
-                // but if the receiver task is busy or the runtime is
-                // congested, we don't want to block the routing table.
-                let mut closed = 0u64;
-                for close_notify in pending_close.drain(..) {
-                    let _ = close_notify.send(());
-                    closed += 1;
-                }
-
-                if closed > 0 {
-                    self.mem_pressure_closes
-                        .fetch_add(closed, Ordering::Relaxed);
-                    warn!(
-                        "memory pressure SEVERE: {} bytes > {}x{} limit, smart-evicted {}/{} connections (target {}, UDP+idle first, hard mode)",
-                        current, ratio_x100, limit_u64, closed, count, to_close
-                    );
-                }
-            }
         }
     }
 }

--- a/clash-lib/src/app/dispatcher/statistics_manager.rs
+++ b/clash-lib/src/app/dispatcher/statistics_manager.rs
@@ -316,7 +316,7 @@ impl Manager {
         // their user counters to 0. upload_total/download_total are untouched
         // so /connections keeps seeing the correct cumulative values.
         let connections = self.connections.lock().await;
-        for (_, (tracked, _)) in connections.iter() {
+        for (tracked, _) in connections.values() {
             let info = tracked.tracker_info();
             if let Some(ref user) = info.session_holder.inbound_user {
                 let upload = info.user_upload.swap(0, Ordering::AcqRel);
@@ -377,7 +377,7 @@ impl Manager {
     pub async fn snapshot(&self) -> Snapshot {
         let mut connections = vec![];
         let conns = self.connections.lock().await;
-        for (_, v) in conns.iter() {
+        for v in conns.values() {
             let t = v.0.tracker_info();
             let chain = t.proxy_chain_holder.0.read().await;
             connections.push(TrackerInfo {

--- a/clash-lib/src/config/def.rs
+++ b/clash-lib/src/config/def.rs
@@ -745,11 +745,8 @@ pub struct EdnsClientSubnet {
 pub struct Experimental {
     /// buffer size for tcp stream bidirectional copy
     pub tcp_buffer_size: Option<usize>,
-    /// buffer size for AnyTLS duplex pipe (default 16384 = 16KB)
-    pub anytls_duplex_buffer_size: Option<usize>,
-    /// buffer size for AnyTLS relay read buffer (default 4096 = 4KB)
-    pub anytls_relay_buffer_size: Option<usize>,
-    /// max entries in the closed-flows ring buffer (default 50, lower saves RAM)
+    /// max entries in the closed-flows ring buffer (default 50, lower saves
+    /// RAM)
     pub closed_flows_cap: Option<usize>,
     #[serde(default)]
     pub ignore_resolve_fail: bool,

--- a/clash-lib/src/config/def.rs
+++ b/clash-lib/src/config/def.rs
@@ -355,7 +355,6 @@ impl Display for LogLevel {
 ///   - DOMAIN-SUFFIX,facebook.com,REJECT
 ///   - DOMAIN-KEYWORD,google,select
 ///   - DOMAIN,google.com,select
-///   - DOMAIN,google.com,select,interface=en0
 ///   - SRC-IP-CIDR,192.168.1.1/24,DIRECT
 ///   - GEOIP,CN,DIRECT
 ///   - DST-PORT,53,trojan
@@ -746,6 +745,12 @@ pub struct EdnsClientSubnet {
 pub struct Experimental {
     /// buffer size for tcp stream bidirectional copy
     pub tcp_buffer_size: Option<usize>,
+    /// buffer size for AnyTLS duplex pipe (default 16384 = 16KB)
+    pub anytls_duplex_buffer_size: Option<usize>,
+    /// buffer size for AnyTLS relay read buffer (default 4096 = 4KB)
+    pub anytls_relay_buffer_size: Option<usize>,
+    /// max entries in the closed-flows ring buffer (default 50, lower saves RAM)
+    pub closed_flows_cap: Option<usize>,
     #[serde(default)]
     pub ignore_resolve_fail: bool,
 }

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -658,12 +658,6 @@ async fn create_components(
 
     let statistics_manager = StatisticsManager::new();
 
-    // Inject the DNS resolver so statistics_manager can clear DNS caches
-    // under memory pressure (see check_memory_pressure).
-    statistics_manager
-        .set_dns_resolver(dns_resolver.clone())
-        .await;
-
     debug!("initializing dispatcher");
     let dispatcher = Arc::new(Dispatcher::new(
         outbound_manager.clone(),
@@ -674,12 +668,7 @@ async fn create_components(
         config.experimental.as_ref().and_then(|e| e.tcp_buffer_size),
     ));
 
-    // Set AnyTLS buffer sizes from experimental config
     if let Some(ref exp) = config.experimental {
-        let duplex = exp.anytls_duplex_buffer_size.unwrap_or(16 * 1024);
-        let relay = exp.anytls_relay_buffer_size.unwrap_or(4 * 1024);
-        crate::proxy::anytls::set_buffer_config(duplex, relay);
-
         if let Some(cap) = exp.closed_flows_cap {
             crate::app::dispatcher::set_closed_flows_cap(cap);
         }

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -656,6 +656,12 @@ async fn create_components(
 
     let statistics_manager = StatisticsManager::new();
 
+    // Inject the DNS resolver so statistics_manager can clear DNS caches
+    // under memory pressure (see check_memory_pressure).
+    statistics_manager
+        .set_dns_resolver(dns_resolver.clone())
+        .await;
+
     debug!("initializing dispatcher");
     let dispatcher = Arc::new(Dispatcher::new(
         outbound_manager.clone(),
@@ -663,8 +669,19 @@ async fn create_components(
         dns_resolver.clone(),
         config.general.mode,
         statistics_manager.clone(),
-        config.experimental.and_then(|e| e.tcp_buffer_size),
+        config.experimental.as_ref().and_then(|e| e.tcp_buffer_size),
     ));
+
+    // Set AnyTLS buffer sizes from experimental config
+    if let Some(ref exp) = config.experimental {
+        let duplex = exp.anytls_duplex_buffer_size.unwrap_or(16 * 1024);
+        let relay = exp.anytls_relay_buffer_size.unwrap_or(4 * 1024);
+        crate::proxy::anytls::set_buffer_config(duplex, relay);
+
+        if let Some(cap) = exp.closed_flows_cap {
+            crate::app::dispatcher::set_closed_flows_cap(cap);
+        }
+    }
 
     debug!("initializing authenticator");
     let authenticator = Arc::new(auth::PlainAuthenticator::new(config.users));

--- a/clash-lib/src/lib.rs
+++ b/clash-lib/src/lib.rs
@@ -668,10 +668,10 @@ async fn create_components(
         config.experimental.as_ref().and_then(|e| e.tcp_buffer_size),
     ));
 
-    if let Some(ref exp) = config.experimental {
-        if let Some(cap) = exp.closed_flows_cap {
-            crate::app::dispatcher::set_closed_flows_cap(cap);
-        }
+    if let Some(ref exp) = config.experimental
+        && let Some(cap) = exp.closed_flows_cap
+    {
+        crate::app::dispatcher::set_closed_flows_cap(cap);
     }
 
     debug!("initializing authenticator");


### PR DESCRIPTION
### Summary
- Introduces lightweight `ClosedFlowInfo` in the closed connection ring buffer, releasing heavy `Session` and `ProxyChain` references immediately upon connection close.
- Resolves an AB-BA lock inversion in `StatisticsManager` by dropping the `connections` lock prior to acquiring stats or ring buffer locks.
- Adds `experimental.closed-flows-cap` configuration option (default 50).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable retention limits for closed-flow records, with a default capacity of 50.
  - Reduced memory usage by retaining lightweight information for closed connections.

- **Bug Fixes**
  - Improved connection cleanup and flow statistics handling to reduce resource usage.
  - Prevented potential locking issues during connection cleanup and statistics processing.

- **Documentation**
  - Updated the example routing rule configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->