### PR TITLE
fix(dns): fakeip bidirectional cache invariants and IP offset cycling

### DIFF
--- a/clash-lib/src/app/dns/fakeip/mem_store.rs
+++ b/clash-lib/src/app/dns/fakeip/mem_store.rs
@@ -38,15 +38,15 @@ impl Store for InMemStore {
     async fn pub_by_host(&mut self, host: &str, ip: std::net::IpAddr) {
         // Maintain bidirectional invariant: remove stale mappings that
         // referenced the old host or IP before inserting the new pair.
-        if let Some(old_host) = self.itoh.remove(&ip) {
-            if old_host != host {
-                self.htoi.remove(&old_host);
-            }
+        if let Some(old_host) = self.itoh.remove(&ip)
+            && old_host != host
+        {
+            self.htoi.remove(&old_host);
         }
-        if let Some(old_ip) = self.htoi.remove(host) {
-            if old_ip != ip {
-                self.itoh.remove(&old_ip);
-            }
+        if let Some(old_ip) = self.htoi.remove(host)
+            && old_ip != ip
+        {
+            self.itoh.remove(&old_ip);
         }
         self.itoh.insert(ip, host.into());
         self.htoi.insert(host.into(), ip);
@@ -57,7 +57,7 @@ impl Store for InMemStore {
         let host_copy = host.clone();
         // Cross-check: if htoi doesn't map this host back to the same IP,
         // the entry is stale.
-        if self.htoi.get(&host_copy).map(|x| *x) != Some(ip) {
+        if self.htoi.get(&host_copy).copied() != Some(ip) {
             self.itoh.remove(&ip);
             return None;
         }
@@ -69,15 +69,15 @@ impl Store for InMemStore {
     async fn put_by_ip(&mut self, ip: std::net::IpAddr, host: &str) {
         // Maintain bidirectional invariant: remove stale mappings that
         // referenced the old host or IP before inserting the new pair.
-        if let Some(old_host) = self.itoh.remove(&ip) {
-            if old_host != host {
-                self.htoi.remove(&old_host);
-            }
+        if let Some(old_host) = self.itoh.remove(&ip)
+            && old_host != host
+        {
+            self.htoi.remove(&old_host);
         }
-        if let Some(old_ip) = self.htoi.remove(host) {
-            if old_ip != ip {
-                self.itoh.remove(&old_ip);
-            }
+        if let Some(old_ip) = self.htoi.remove(host)
+            && old_ip != ip
+        {
+            self.itoh.remove(&old_ip);
         }
         self.itoh.insert(ip, host.into());
         self.htoi.insert(host.into(), ip);
@@ -92,7 +92,7 @@ impl Store for InMemStore {
     async fn exist(&mut self, ip: std::net::IpAddr) -> bool {
         // An IP exists only if both forward and reverse mappings agree.
         match self.itoh.get(&ip) {
-            Some(host) => self.htoi.get(host).map(|x| *x) == Some(ip),
+            Some(host) => self.htoi.get(host).copied() == Some(ip),
             None => false,
         }
     }

--- a/clash-lib/src/app/dns/fakeip/mem_store.rs
+++ b/clash-lib/src/app/dns/fakeip/mem_store.rs
@@ -21,25 +21,66 @@ impl InMemStore {
 #[async_trait]
 impl Store for InMemStore {
     async fn get_by_host(&mut self, host: &str) -> Option<std::net::IpAddr> {
-        self.htoi.get_mut(host).map(|ip| {
-            self.itoh.get_mut(ip);
-            *ip
-        })
+        let ip = self.htoi.get_mut(host)?;
+        let ip_copy = *ip;
+        // Cross-check: if itoh doesn't map this IP back to the same host,
+        // the entry is stale (e.g. htoi survived but itoh was evicted and
+        // the IP was reassigned).  Treat as a miss and clean up.
+        if self.itoh.get(&ip_copy).map(|h| h.as_str()) != Some(host) {
+            self.htoi.remove(host);
+            return None;
+        }
+        // Touch itoh LRU to keep access ordering in sync.
+        self.itoh.get_mut(&ip_copy);
+        Some(ip_copy)
     }
 
     async fn pub_by_host(&mut self, host: &str, ip: std::net::IpAddr) {
+        // Maintain bidirectional invariant: remove stale mappings that
+        // referenced the old host or IP before inserting the new pair.
+        if let Some(old_host) = self.itoh.remove(&ip) {
+            if old_host != host {
+                self.htoi.remove(&old_host);
+            }
+        }
+        if let Some(old_ip) = self.htoi.remove(host) {
+            if old_ip != ip {
+                self.itoh.remove(&old_ip);
+            }
+        }
+        self.itoh.insert(ip, host.into());
         self.htoi.insert(host.into(), ip);
     }
 
     async fn get_by_ip(&mut self, ip: std::net::IpAddr) -> Option<String> {
-        self.itoh.get_mut(&ip).map(|h| {
-            self.htoi.get_mut(h);
-            h.to_string()
-        })
+        let host = self.itoh.get_mut(&ip)?;
+        let host_copy = host.clone();
+        // Cross-check: if htoi doesn't map this host back to the same IP,
+        // the entry is stale.
+        if self.htoi.get(&host_copy).map(|x| *x) != Some(ip) {
+            self.itoh.remove(&ip);
+            return None;
+        }
+        // Touch htoi LRU to keep access ordering in sync.
+        self.htoi.get_mut(&host_copy);
+        Some(host_copy)
     }
 
     async fn put_by_ip(&mut self, ip: std::net::IpAddr, host: &str) {
+        // Maintain bidirectional invariant: remove stale mappings that
+        // referenced the old host or IP before inserting the new pair.
+        if let Some(old_host) = self.itoh.remove(&ip) {
+            if old_host != host {
+                self.htoi.remove(&old_host);
+            }
+        }
+        if let Some(old_ip) = self.htoi.remove(host) {
+            if old_ip != ip {
+                self.itoh.remove(&old_ip);
+            }
+        }
         self.itoh.insert(ip, host.into());
+        self.htoi.insert(host.into(), ip);
     }
 
     async fn del_by_ip(&mut self, ip: std::net::IpAddr) {
@@ -49,7 +90,11 @@ impl Store for InMemStore {
     }
 
     async fn exist(&mut self, ip: std::net::IpAddr) -> bool {
-        self.itoh.contains_key(&ip)
+        // An IP exists only if both forward and reverse mappings agree.
+        match self.itoh.get(&ip) {
+            Some(host) => self.htoi.get(host).map(|x| *x) == Some(ip),
+            None => false,
+        }
     }
 
     async fn copy_to(&self, #[allow(unused)] store: &mut Box<dyn Store>) {

--- a/clash-lib/src/app/dns/fakeip/mem_store.rs
+++ b/clash-lib/src/app/dns/fakeip/mem_store.rs
@@ -16,85 +16,75 @@ impl InMemStore {
             htoi: lru_time_cache::LruCache::with_capacity(size),
         }
     }
+
+    /// Insert or update a bidirectional mapping `host <-> ip`, ensuring that
+    /// any old conflicting associations for either the host or the IP are
+    /// purged.
+    fn insert_pair(&mut self, host: &str, ip: IpAddr) {
+        if let Some(old_host) = self.itoh.remove(&ip)
+            && old_host != host
+        {
+            self.htoi.remove(&old_host);
+        }
+        if let Some(old_ip) = self.htoi.remove(host)
+            && old_ip != ip
+        {
+            self.itoh.remove(&old_ip);
+        }
+        self.itoh.insert(ip, host.to_string());
+        self.htoi.insert(host.to_string(), ip);
+    }
 }
 
 #[async_trait]
 impl Store for InMemStore {
-    async fn get_by_host(&mut self, host: &str) -> Option<std::net::IpAddr> {
-        let ip = self.htoi.get_mut(host)?;
-        let ip_copy = *ip;
+    async fn get_by_host(&mut self, host: &str) -> Option<IpAddr> {
+        let ip = *self.htoi.get_mut(host)?;
         // Cross-check: if itoh doesn't map this IP back to the same host,
         // the entry is stale (e.g. htoi survived but itoh was evicted and
-        // the IP was reassigned).  Treat as a miss and clean up.
-        if self.itoh.get(&ip_copy).map(|h| h.as_str()) != Some(host) {
+        // the IP was reassigned). Treat as a miss and clean up.
+        if self.itoh.get(&ip).map(|h| h.as_str()) != Some(host) {
             self.htoi.remove(host);
             return None;
         }
         // Touch itoh LRU to keep access ordering in sync.
-        self.itoh.get_mut(&ip_copy);
-        Some(ip_copy)
+        self.itoh.get_mut(&ip);
+        Some(ip)
     }
 
-    async fn pub_by_host(&mut self, host: &str, ip: std::net::IpAddr) {
-        // Maintain bidirectional invariant: remove stale mappings that
-        // referenced the old host or IP before inserting the new pair.
-        if let Some(old_host) = self.itoh.remove(&ip)
-            && old_host != host
-        {
-            self.htoi.remove(&old_host);
-        }
-        if let Some(old_ip) = self.htoi.remove(host)
-            && old_ip != ip
-        {
-            self.itoh.remove(&old_ip);
-        }
-        self.itoh.insert(ip, host.into());
-        self.htoi.insert(host.into(), ip);
+    async fn pub_by_host(&mut self, host: &str, ip: IpAddr) {
+        self.insert_pair(host, ip);
     }
 
-    async fn get_by_ip(&mut self, ip: std::net::IpAddr) -> Option<String> {
+    async fn get_by_ip(&mut self, ip: IpAddr) -> Option<String> {
         let host = self.itoh.get_mut(&ip)?;
-        let host_copy = host.clone();
         // Cross-check: if htoi doesn't map this host back to the same IP,
         // the entry is stale.
-        if self.htoi.get(&host_copy).copied() != Some(ip) {
+        if self.htoi.get(host).copied() != Some(ip) {
             self.itoh.remove(&ip);
             return None;
         }
+        let host = host.clone();
         // Touch htoi LRU to keep access ordering in sync.
-        self.htoi.get_mut(&host_copy);
-        Some(host_copy)
+        self.htoi.get_mut(&host);
+        Some(host)
     }
 
-    async fn put_by_ip(&mut self, ip: std::net::IpAddr, host: &str) {
-        // Maintain bidirectional invariant: remove stale mappings that
-        // referenced the old host or IP before inserting the new pair.
-        if let Some(old_host) = self.itoh.remove(&ip)
-            && old_host != host
-        {
-            self.htoi.remove(&old_host);
-        }
-        if let Some(old_ip) = self.htoi.remove(host)
-            && old_ip != ip
-        {
-            self.itoh.remove(&old_ip);
-        }
-        self.itoh.insert(ip, host.into());
-        self.htoi.insert(host.into(), ip);
+    async fn put_by_ip(&mut self, ip: IpAddr, host: &str) {
+        self.insert_pair(host, ip);
     }
 
-    async fn del_by_ip(&mut self, ip: std::net::IpAddr) {
+    async fn del_by_ip(&mut self, ip: IpAddr) {
         if let Some(host) = self.itoh.remove(&ip) {
             self.htoi.remove(&host);
         }
     }
 
-    async fn exist(&mut self, ip: std::net::IpAddr) -> bool {
+    async fn exist(&mut self, ip: IpAddr) -> bool {
         // An IP exists only if both forward and reverse mappings agree.
-        match self.itoh.get(&ip) {
-            Some(host) => self.htoi.get(host).copied() == Some(ip),
-            None => false,
-        }
+        self.itoh
+            .get(&ip)
+            .is_some_and(|host| self.htoi.get(host).copied() == Some(ip))
     }
 
     async fn copy_to(&self, #[allow(unused)] store: &mut Box<dyn Store>) {

--- a/clash-lib/src/app/dns/fakeip/mod.rs
+++ b/clash-lib/src/app/dns/fakeip/mod.rs
@@ -60,7 +60,7 @@ impl FakeDns {
             max,
             min,
             gateway: min - 1,
-            offset: 0,
+            offset: total - 1,
             skipped_hostnames: opt.skipped_hostnames,
             ipnet: opt.ipnet,
             store: opt.store,
@@ -136,22 +136,22 @@ impl FakeDns {
         let current = self.offset;
 
         loop {
-            self.offset = (self.offset + 1) % (self.max - self.min);
+            self.offset = (self.offset + 1) % (self.max - self.min + 1);
 
             if self.offset == current {
-                self.offset = (self.offset + 1) % (self.max - self.min);
-                let ip = net::Ipv4Addr::from(self.min + self.offset - 1);
+                self.offset = (self.offset + 1) % (self.max - self.min + 1);
+                let ip = net::Ipv4Addr::from(self.min + self.offset);
                 self.store.del_by_ip(std::net::IpAddr::V4(ip)).await;
                 break;
             }
 
-            let ip = net::Ipv4Addr::from(self.min + self.offset - 1);
+            let ip = net::Ipv4Addr::from(self.min + self.offset);
             if !self.store.exist(std::net::IpAddr::V4(ip)).await {
                 break;
             }
         }
 
-        let ip = net::Ipv4Addr::from(self.min + self.offset - 1);
+        let ip = net::Ipv4Addr::from(self.min + self.offset);
         self.store.put_by_ip(std::net::IpAddr::V4(ip), host).await;
         std::net::IpAddr::V4(ip)
     }
@@ -215,11 +215,16 @@ mod tests {
         let foo = pool.lookup("foo.com").await;
         let bar = pool.lookup("bar.com").await;
 
-        for i in 0..3 {
+        // Fill all 6 IPs in the /29 pool (min=192.168.0.2, max=192.168.0.7).
+        // foo and bar already use 2, so 4 more are needed to fill the pool.
+        for i in 0..4 {
             pool.lookup(&format!("{}.com", i)).await;
         }
 
+        // Pool is now full — baz must recycle foo's IP (oldest entry).
         let baz = pool.lookup("baz.com").await;
+        // foo.com's forward mapping was cleaned up by put_by_ip, so the next
+        // lookup allocates a fresh IP (bar's recycled IP).
         let next = pool.lookup("foo.com").await;
         assert_eq!(foo, baz);
         assert_eq!(next, bar);

--- a/clash-lib/src/app/dns/fakeip/mod.rs
+++ b/clash-lib/src/app/dns/fakeip/mod.rs
@@ -78,27 +78,22 @@ impl FakeDns {
     }
 
     pub async fn reverse_lookup(&mut self, ip: net::IpAddr) -> Option<String> {
-        if !ip.is_ipv4() {
-            None
-        } else {
+        if ip.is_ipv4() {
             self.store.get_by_ip(ip).await
+        } else {
+            None
         }
     }
 
     pub fn should_skip(&self, domain: &str) -> bool {
-        match &self.skipped_hostnames {
-            None => false,
-            Some(host) => host.search(domain).is_some(),
-        }
+        self.skipped_hostnames
+            .as_ref()
+            .is_some_and(|host| host.search(domain).is_some())
     }
 
     #[allow(dead_code)]
     pub async fn exist(&mut self, ip: net::IpAddr) -> bool {
-        if !ip.is_ipv4() {
-            false
-        } else {
-            self.store.exist(ip).await
-        }
+        ip.is_ipv4() && self.store.exist(ip).await
     }
 
     pub async fn is_fake_ip(&mut self, ip: net::IpAddr) -> bool {
@@ -132,28 +127,33 @@ impl FakeDns {
         src.store.copy_to(&mut self.store).await;
     }
 
+    fn current_ip(&self) -> net::IpAddr {
+        net::IpAddr::V4(net::Ipv4Addr::from(self.min + self.offset))
+    }
+
     async fn get(&mut self, host: &str) -> net::IpAddr {
+        let pool_size = self.max - self.min + 1;
         let current = self.offset;
 
         loop {
-            self.offset = (self.offset + 1) % (self.max - self.min + 1);
+            self.offset = (self.offset + 1) % pool_size;
+            let ip = self.current_ip();
 
             if self.offset == current {
-                self.offset = (self.offset + 1) % (self.max - self.min + 1);
-                let ip = net::Ipv4Addr::from(self.min + self.offset);
-                self.store.del_by_ip(std::net::IpAddr::V4(ip)).await;
+                self.offset = (self.offset + 1) % pool_size;
+                let ip = self.current_ip();
+                self.store.del_by_ip(ip).await;
                 break;
             }
 
-            let ip = net::Ipv4Addr::from(self.min + self.offset);
-            if !self.store.exist(std::net::IpAddr::V4(ip)).await {
+            if !self.store.exist(ip).await {
                 break;
             }
         }
 
-        let ip = net::Ipv4Addr::from(self.min + self.offset);
-        self.store.put_by_ip(std::net::IpAddr::V4(ip), host).await;
-        std::net::IpAddr::V4(ip)
+        let ip = self.current_ip();
+        self.store.put_by_ip(ip, host).await;
+        ip
     }
 
     fn ip_to_uint(ip: &net::Ipv4Addr) -> u32 {


### PR DESCRIPTION
### Summary
- Enforces bidirectional consistency between `itoh` and `htoi` in `InMemStore` by evicting stale pairs prior to new insertions.
- Fixes off-by-one modulo calculation in FakeIP pool cycling (`max - min + 1`).
- Updates unit tests covering full pool capacity and eviction behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fake DNS mapping consistency by detecting and removing stale or mismatched host-to-IP entries.
  * Corrected IP allocation across the full configured pool range.
  * Improved address recycling when the fake IP pool is full.
  * Ensured recycled addresses no longer retain outdated mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->